### PR TITLE
Showing calculate actions for robot pilots when base ship has focus

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -1740,6 +1740,12 @@ exportObj.basicCardData = ->
                 "Title"
                 "Illicit"
             ]
+            ship_override:
+                actions: [
+                    "Calculate"
+                    "Target Lock"
+                    "Rotate Arc"
+                ]
         }
         {
             name: "Wild Space Fringer"
@@ -2100,6 +2106,12 @@ exportObj.basicCardData = ->
                 "Turret"
                 "Title"
             ]
+            ship_override:
+                actions: [
+                    "Calculate"
+                    "Target Lock"
+                    "Reinforce"
+                ]
         }
         {
             name: "Lothal Rebel"
@@ -2587,6 +2599,12 @@ exportObj.basicCardData = ->
                 "Modification"
                 "Title"
             ]
+            ship_override:
+                actions: [
+                    "Calculate"
+                    "Target Lock"
+                    "Rotate Arc"
+                ]
         }
         {
             name: "Freighter Captain"
@@ -2648,6 +2666,11 @@ exportObj.basicCardData = ->
                 "Crew"
                 "Modification"
               ]
+            ship_override:
+                actions: [
+                    "Calculate"
+                    "Barrel Roll"
+                ]
         }
         {
             name: "Autopilot Drone"
@@ -2660,6 +2683,12 @@ exportObj.basicCardData = ->
             points: 12
             slots: [
             ]
+            ship_override:
+                actions: [
+                    "Calculate"
+                    "Barrel Roll"
+                ]
+
         }
         {
             name: "Fenn Rau (Fang Fighter)"
@@ -2865,6 +2894,13 @@ exportObj.basicCardData = ->
                 "Modification"
                 "Title"
               ]
+            ship_override:
+                actions: [
+                    "Calculate"
+                    "Target Lock"
+                    "Jam"
+                ]
+
         }
         {
             name: "Zuckuss"
@@ -3477,6 +3513,15 @@ exportObj.basicCardData = ->
                 "Modification"
                 "Title"
               ]
+            ship_override:
+                actions: [
+                    "Calculate"
+                    "Target Lock"
+                    "Barrel Roll"
+                    "<r>> Calculate</r>"
+                    "Boost"
+                    "<r>> Calculate</r>"
+                ]
         }
         {
             name: "Prince Xizor"

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -1514,10 +1514,6 @@ class exportObj.SquadBuilder
                     else
                         @info_container.find('.info-collection').text ''
                     effective_stats = data.effectiveStats()
-                    extra_actions = $.grep effective_stats.actions, (el, i) ->
-                        el not in data.data.actions
-                    extra_actions_red = $.grep effective_stats.actionsred, (el, i) ->
-                        el not in data.data.actionsred
                     @info_container.find('.info-name').html """#{if data.pilot.unique then "&middot;&nbsp;" else ""}#{data.pilot.name}#{if data.pilot.epic? then " (#{exportObj.translate(@language, 'ui', 'epic')})" else ""}#{if exportObj.isReleased(data.pilot) then "" else " (#{exportObj.translate(@language, 'ui', 'unreleased')})"}"""
                     @info_container.find('p.info-text').html data.pilot.text ? ''
                     @info_container.find('tr.info-ship td.info-data').text data.pilot.ship
@@ -1570,11 +1566,11 @@ class exportObj.SquadBuilder
                         @info_container.find('tr.info-charge').show()
                     else
                         @info_container.find('tr.info-charge').hide()
-                        
-                    @info_container.find('tr.info-actions td.info-data').html (exportObj.translate(@language, 'action', a) for a in data.data.actions.concat( ("<strong>#{exportObj.translate @language, 'action', action}</strong>" for action in extra_actions))).join ' '
+
+                    @info_container.find('tr.info-actions td.info-data').html (exportObj.translate(@language, 'action', a) for a in (data.pilot.ship_override?.actions ? data.data.actions)).join ' '
 
                     if data.data.actionsred?
-                        @info_container.find('tr.info-actions-red td.info-data-red').html (exportObj.translate(@language, 'action', a) for a in data.data.actionsred.concat( ("<strong>#{exportObj.translate @language, 'action', action}</strong>" for action in extra_actions_red))).join ' '
+                        @info_container.find('tr.info-actions-red td.info-data-red').html (exportObj.translate(@language, 'action', a) for a in (data.pilot.ship_override?.actionsred ? data.data.actionsred)).join ' '
                     @info_container.find('tr.info-actions-red').toggle(data.data.actionsred?)
                     
                     @info_container.find('tr.info-actions').show()
@@ -1641,7 +1637,7 @@ class exportObj.SquadBuilder
                         @info_container.find('tr.info-charge').show()
                     else
                         @info_container.find('tr.info-charge').hide()
-                    
+
                     @info_container.find('tr.info-actions td.info-data').html (exportObj.translate(@language, 'action', action) for action in (data.ship_override?.actions ? exportObj.ships[data.ship].actions)).join(' ')
     
                     if ships[data.ship].actionsred?


### PR DESCRIPTION
Took advantage of the already implemented `ship_override` code, and added the "Calculate" action to the pilots where the base ship has "Focus".

(btw, I've made some other PRs against the original YASB, so I'm familiar with this codebase)

<img width="349" alt="l3-37" src="https://user-images.githubusercontent.com/58073/43976504-d7b0cb9e-9cae-11e8-8f19-2641a2ff5c24.png">

<img width="340" alt="guri" src="https://user-images.githubusercontent.com/58073/43976943-81c2cf5a-9cb0-11e8-8e0b-fdab391420f9.png">
