### PR TITLE
Fix Phantom in German

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -6911,9 +6911,7 @@ exportObj.basicCardData = ->
            unique: true
            faction: "Rebel Alliance"
            restriction_func: (ship) ->
-                builder = ship.builder
-                return true if builder.ship == "Attack Shuttle" or "Sheathipede-Class Shuttle"
-                false
+                return (ship.data.name == "Attack Shuttle" or ship.data.name == "Sheathipede-Class Shuttle")
        }
        {
             name: "Hardpoint: Cannon"

--- a/coffeescripts/cards-de.coffee
+++ b/coffeescripts/cards-de.coffee
@@ -1275,9 +1275,7 @@ exportObj.cardLoaders.Deutsch = () ->
            name: """Phantom"""
            text: """<i>Nur für Rebellen</i>%LINEBREAK%Du kannst in Reichweite 0-1 andocken."""
            restriction_func: (ship) ->
-                builder = ship.builder
-                return true if builder.ship == "Jagdshuttle" or "Raumfähre der Sheathipede-Klasse"
-                false
+                return (ship.data.name == "Jagdshuttle" or ship.data.name == "Raumfähre der Sheathipede-Klasse")
         "Punishing One":
            name: """Vollstrecker Eins"""
            ship: """JumpMaster 5000"""


### PR DESCRIPTION
We should really start distinguishing between internal names and display names, so logic does not depend on translations. 

This would also fix stuff like background images not shown for languages other than english, and all the errors beeing thrown from the collection beeing unable to figure out which ships are owned. 