### PR TITLE
Small fixes on the Spanish translation

### DIFF
--- a/coffeescripts/cards-es.coffee
+++ b/coffeescripts/cards-es.coffee
@@ -397,7 +397,7 @@ exportObj.cardLoaders['Español'] = () ->
            display_name: """Phoenix Squadron Pilot"""
            text: """<i>Bajo el mando del comandante Jun Sato, los valerosos pero inexpertos pilotos del Escuadrón Fénix se enfrentan al Imperio Galáctico teniéndolo todo en su contra.</i>%LINEBREAK%Propulsores vectoriales: Después de que realices una acción, puedes realizar una acción %BOOST% roja."""
         "Planetary Sentinel":
-           display_name: """Planetary Sentinel"""
+           display_name: """Centinela planetario"""
            text: """<i>Para proteger sus muchas instalaciones militares, el Imperio precisa de una fuerza de defensa rápida y vigilante.</i>%LINEBREAK%Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra [1 %BANKLEFT%], [1 %STRAIGHT%] o [1 %BANKRIGHT%] de color blanco."""
         "Rebel Scout":
            display_name: """Explorador rebelde"""
@@ -880,67 +880,67 @@ exportObj.cardLoaders['Español'] = () ->
            display_name: """Zuckuss"""
            text: """Mientras efectúas un ataque principal, puedes tirar 1 dado de ataque adicional. Si lo haces, el defensor tira 1 dado de defensa adicional."""
        '"Chopper"':
-           display_name: """“Chopper”"""
+           display_name: """„Chopper”"""
            text: """Al comienzo de la fase de Enfrentamiento, toda nave enemiga que tengas a alcance 0 recibe 2 fichas de Interferencia.%LINEBREAK%Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal %REARARC% con un valor de Ataque igual al del armamento principal %FRONTARC% de tu nave acoplada."""
        '"Countdown"':
-           display_name: """“Cuenta Atrás”"""
+           display_name: """„Cuenta Atrás”"""
            text: """Mientras te defiendes, después del paso de “Neutralizar los resultados”, puedes sufrir 1 de daño %HIT% y recibir 1 ficha de Tensión. Si lo haces, anula todos los resultados de los dados.%LINEBREAK%Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra [1 %BANKLEFT%], [1 %STRAIGHT%] o [1 %BANKRIGHT%] de color blanco."""
        '"Deathfire"':
-           display_name: """“Muerte Ígnea”"""
+           display_name: """„Muerte Ígnea”"""
            text: """Después de que seas destruido, antes de ser retirado de la zona de juego, puedes efectuar un ataque y soltar o lanzar 1 dispositivo. %LINEBREAK%Bombardero ágil: Si vas a soltar un dispositivo utilizando una plantilla %STRAIGHT%, en vez de esa plantilla puedes utilizar una plantilla %BANKLEFT% o %BANKRIGHT% con la misma velocidad."""
        '"Deathrain"':
-           display_name: """“Lluvia de Muerte”"""
+           display_name: """„Lluvia de Muerte”"""
            text: """Después de que sueltes o lances un dispositivo, puedes realizar una acción."""
        '"Double Edge"':
-           display_name: """“Doble Filo”"""
+           display_name: """„Doble Filo”"""
            text: """Después de que efectúes un ataque %TURRET% o %MISSILE% que falle, puedes realizar un ataque adicional utilizando un arma diferente."""
        '"Duchess"':
-           display_name: """“Duquesa”"""
+           display_name: """„Duquesa”"""
            text: """Puedes elegir no utilizar tus alerones adaptativos.%LINEBREAK%Puedes utilizar tus alerones adaptativos incluso aunque estés bajo tensión.%LINEBREAK%Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra blanca [1 %BANKLEFT%], [1 %STRAIGHT%] o [1 %BANKRIGHT%]."""
        '"Dutch" Vander':
-           display_name: """“Dutch” Vander"""
+           display_name: """„Dutch” Vander"""
            text: """Después de que realices la acción %LOCK%, puedes elegir 1 nave aliada que tengas a alcance 1-3. Esa nave puede obtener un Blanco fijado sobre el objeto que acabas de fijar como blanco, ignorando las restricciones por alcance."""
        '"Echo"':
-           display_name: """“Eco”"""
+           display_name: """„Eco”"""
            text: """Mientras desactivas el camuflaje, debes utilizar la plantilla [2 %BANKLEFT%] o [2 %BANKRIGHT%] en vez de la plantilla [2 %STRAIGHT%].%LINEBREAK%Matriz de estigio: Después de que desactives el camuflaje, puedes realizar una acción %EVADE%. Al comienzo de la fase Final, puedes gastar 1 ficha de Evasión para recibir 1 ficha de Camuflaje."""
        '"Howlrunner"':
-           display_name: """“Aullador Veloz”"""
+           display_name: """„Aullador Veloz”"""
            text: """Mientras una nave aliada que tienes a alcance 0-1 efectúa un ataque principal, esa nave puede volver a tirar 1 dado de ataque."""
        '"Leebo"':
-           display_name: """“Leebo”"""
+           display_name: """„Leebo”"""
            text: """Después de que te defiendas o efectúes un ataque, si gastaste una ficha de Cálculos, recibes 1 ficha de Cálculos.%LINEBREAK%Punto ciego en los sensores: Mientras efectúas un ataque principal a alcance de ataque 0-1, no apliques el modificador por alcance 0-1 y tira 1 dado de ataque menos."""
        '"Mauler" Mithel':
-           display_name: """“Mutilador” Mithel"""
+           display_name: """„Mutilador” Mithel"""
            text: """Mientras efectúas un ataque a alcance de ataque 1, tira 1 dado de ataque adicional."""
        '"Night Beast"':
-           display_name: """“Bestia Nocturna”"""
+           display_name: """„Bestia Nocturna”"""
            text: """Después de que ejecutes completamente una maniobra azul, puedes realizar una acción %FOCUS%."""
        '"Pure Sabacc"':
-           display_name: """“Sabacc Puro”"""
+           display_name: """„Sabacc Puro”"""
            text: """Mientras efectúas un ataque, si tienes 1 o menos cartas de Daño, puedes tirar 1 dado de ataque adicional.%LINEBREAK%Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra [1 %BANKLEFT%], [1 %STRAIGHT%] o [1 %BANKRIGHT%] de color blanco."""
        '"Redline"':
-           display_name: """“Velocidad Terminal”"""
+           display_name: """„Velocidad Terminal”"""
            text: """Puedes mantener hasta 2 Blancos fijados.%LINEBREAK%Después de que realices una acción, puedes obtener un Blanco fijado."""
        '"Scourge" Skutu':
-           display_name: """“Azote” Skutu"""
+           display_name: """„Azote” Skutu"""
            text: """Mientras efectúas un ataque contra un defensor situado en tu %BULLSEYEARC%, tira 1 dado de ataque adicional."""
        '"Vizier"':
-           display_name: """“Visir”"""
+           display_name: """„Visir”"""
            text: """<smallbody>Después de que ejecutes completamente una maniobra de velocidad 1 utilizando la capacidad <strong>Alerones adaptativos</strong> de tu nave, puedes realizar una acción %COORDINATE%. Si lo haces, omite tu paso de “Realizar una acción”.</smallbody>%LINEBREAK%<sasmall><strong>Alerones adaptativos:</strong> Antes de revelar tu selector, si no estás bajo tensión, <b>debes</b> ejecutar una maniobra [1&nbsp;%BANKLEFT%], [1&nbsp;%STRAIGHT%] o [1&nbsp;%BANKRIGHT%] blanca.</sasmall>"""
        '"Wampa"':
-           display_name: """“Wampa”"""
+           display_name: """„Wampa”"""
            text: """Mientras efectúas un ataque, puedes gastar 1 %CHARGE% para tirar 1 dado de ataque adicional.%LINEBREAK%Después de que te defiendas, pierdes 1 %CHARGE%."""
        '"Whisper"':
-           display_name: """“Susurro”"""
+           display_name: """„Susurro”"""
            text: """Después de que efectúes un ataque que impacte, recibes 1 ficha de Evasión.%LINEBREAK%Matriz de estigio: Después de que desactives el camuflaje, puedes realizar una acción %EVADE%. Al comienzo de la fase Final, puedes gastar 1 ficha de Evasión para recibir 1 ficha de Camuflaje."""
        '"Zeb" Orrelios':
-           display_name: """“Zeb” Orrelios"""
+           display_name: """„Zeb” Orrelios"""
            text: """Mientras te defiendes, los resultados %CRIT% se neutralizan antes que los resultados %HIT%.%LINEBREAK%Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal %FRONTARC% o %TURRET%, puede efectuar un ataque principal %REARARC% adicional."""
        '"Zeb" Orrelios (Sheathipede)':
-           display_name: """“Zeb” Orrelios (Sheathipede)"""
+           display_name: """„Zeb” Orrelios (Sheathipede)"""
            text: """Mientras te defiendes, los resultados %CRIT% se neutralizan antes que los resultados %HIT%.%LINEBREAK%Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere %COORDINATE%. Antes de que tu nave nodriza se active, puede realizar una acción %COORDINATE%."""
        '"Zeb" Orrelios (TIE Fighter)':
-           display_name: """“Zeb” Orrelios (TIE Fighter)"""
+           display_name: """„Zeb” Orrelios (TIE Fighter)"""
            text: """Mientras te defiendes, los resultados %CRIT% se neutralizan antes que los resultados %HIT%."""
 
 
@@ -1238,7 +1238,7 @@ exportObj.cardLoaders['Español'] = () ->
            text: """Antes de que vayas a ejecutar una maniobra, puedes gastar 1 escudo. Si lo haces, ejecutas una maniobra [0 %STOP%] blanca en vez de la maniobra que has revelado, y luego recibes 1 ficha de Tensión."""
         "Informant":
            display_name: """Confidente"""
-           text: """<strong>Preparación:<strong> Después de desplegar las fuerzas, elige 1 nave enemiga y asígnale el Estado <strong>Dispositivo de escucha</strong>."""
+           text: """<strong>Preparación:</strong> Después de desplegar las fuerzas, elige 1 nave enemiga y asígnale el Estado <strong>Dispositivo de escucha</strong>."""
         "Instinctive Aim":
            display_name: """Puntería instintiva"""
            text: """Mientras efectúas un ataque especial, puedes gastar 1 %FORCE% para ignorar el requisito %FOCUS% o %LOCK%."""
@@ -1468,16 +1468,16 @@ exportObj.cardLoaders['Español'] = () ->
            display_name: """Zuckuss"""
            text: """<i>Sólo Escoria</i>%LINEBREAK%Mientras efectúas un ataque, si no estás bajo tensión, puedes elegir 1 dado de defensa y recibir 1 ficha de Tensión. Si lo haces, el defensor debe volver a tirar ese dado."""
        '"Chopper" (Crew)':
-           display_name: """“Chopper” (Crew)"""
+           display_name: """„Chopper” (Crew)"""
            text: """<i>Sólo Rebelde</i>%LINEBREAK%Durante el paso de “Realizar una acción”, puedes realizar 1 acción, incluso aunque estés bajo tensión. Después de que realices una acción mientras estás bajo tensión, sufres 1 de daño %HIT% a menos que expongas 1 de tus cartas de Daño."""
        '"Chopper" (Astromech)':
-           display_name: """“Chopper” (Astromech)"""
+           display_name: """„Chopper” (Astromech)"""
            text: """<i>Sólo Rebelde</i>%LINEBREAK%<strong>Acción:</strong> Gasta 1&nbsp;%CHARGE% no recurrente de otra carta de Mejora que tengas equipada para recuperar 1 escudo.%LINEBREAK%<strong>Acción:</strong> Gasta 2 escudos para recuperar 1&nbsp;%CHARGE% no recurrente sobre una mejora que tengas equipada."""
        '"Genius"':
-           display_name: """“Genio”"""
+           display_name: """„Genio”"""
            text: """<i>Sólo Escoria</i>%LINEBREAK%Después de que ejecutes completamente una maniobra, si no has soltado ni lanzado ningún dispositivo en esta ronda, puedes soltar 1 bomba."""
        '"Zeb" Orrelios':
-           display_name: """“Zeb” Orrelios"""
+           display_name: """„Zeb” Orrelios"""
            text: """<i>Sólo Rebelde</i>%LINEBREAK%Eres capaz de efectuar ataques principales a alcance 0. Las naves enemigas que tengas a alcance 0 son capaces de efectuar ataques principales contra ti."""
 
 
@@ -1534,7 +1534,7 @@ exportObj.cardLoaders['Español'] = () ->
            text: '''Durante la fase de Sistemas, si hay alguna nave enemiga con la mejora <strong>Confidente</strong> situada a alcance 0-2 de ti, dale la vuelta a tu selector para dejarlo boca arriba.'''
         'Optimized Prototype':
            display_name: """Prototipo optimizado"""
-           text: '''Cuando estés efectuando un ataque de armamento principal %FRONTARC% contra una nave que esté fijada como blanco por un anave aliada equipada con la mejora <strong>Director Krennic</strong> puedes gastar 1 resultado %HIT%/%CRIT%/%FOCUS%. Si lo haces, elige entre: el defensor pierde 1 ficha de Escudos, o el defensor le da la vuelta a 1 de sus cartas de Daño que tenga boca abajo.'''
+           text: '''Cuando estés efectuando un ataque de armamento principal %FRONTARC% contra una nave que esté fijada como blanco por una nave aliada equipada con la mejora <strong>Director Krennic</strong> puedes gastar 1 resultado %HIT%, %CRIT% o %FOCUS%. Si lo haces, elige entre: el defensor pierde 1 ficha de Escudos, o el defensor le da la vuelta a 1 de sus cartas de Daño que tenga boca abajo.'''
         '''I'll Show You the Dark Side''':
            text: ''' ??? '''
         'Proton Bomb':

--- a/coffeescripts/cards-es.coffee
+++ b/coffeescripts/cards-es.coffee
@@ -880,67 +880,67 @@ exportObj.cardLoaders['Español'] = () ->
            display_name: """Zuckuss"""
            text: """Mientras efectúas un ataque principal, puedes tirar 1 dado de ataque adicional. Si lo haces, el defensor tira 1 dado de defensa adicional."""
        '"Chopper"':
-           display_name: """„Chopper”"""
+           display_name: """„Chopper“"""
            text: """Al comienzo de la fase de Enfrentamiento, toda nave enemiga que tengas a alcance 0 recibe 2 fichas de Interferencia.%LINEBREAK%Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal %REARARC% con un valor de Ataque igual al del armamento principal %FRONTARC% de tu nave acoplada."""
        '"Countdown"':
-           display_name: """„Cuenta Atrás”"""
+           display_name: """„Cuenta Atrás“"""
            text: """Mientras te defiendes, después del paso de “Neutralizar los resultados”, puedes sufrir 1 de daño %HIT% y recibir 1 ficha de Tensión. Si lo haces, anula todos los resultados de los dados.%LINEBREAK%Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra [1 %BANKLEFT%], [1 %STRAIGHT%] o [1 %BANKRIGHT%] de color blanco."""
        '"Deathfire"':
-           display_name: """„Muerte Ígnea”"""
+           display_name: """„Muerte Ígnea“"""
            text: """Después de que seas destruido, antes de ser retirado de la zona de juego, puedes efectuar un ataque y soltar o lanzar 1 dispositivo. %LINEBREAK%Bombardero ágil: Si vas a soltar un dispositivo utilizando una plantilla %STRAIGHT%, en vez de esa plantilla puedes utilizar una plantilla %BANKLEFT% o %BANKRIGHT% con la misma velocidad."""
        '"Deathrain"':
-           display_name: """„Lluvia de Muerte”"""
+           display_name: """„Lluvia de Muerte“"""
            text: """Después de que sueltes o lances un dispositivo, puedes realizar una acción."""
        '"Double Edge"':
-           display_name: """„Doble Filo”"""
+           display_name: """„Doble Filo“"""
            text: """Después de que efectúes un ataque %TURRET% o %MISSILE% que falle, puedes realizar un ataque adicional utilizando un arma diferente."""
        '"Duchess"':
-           display_name: """„Duquesa”"""
+           display_name: """„Duquesa“"""
            text: """Puedes elegir no utilizar tus alerones adaptativos.%LINEBREAK%Puedes utilizar tus alerones adaptativos incluso aunque estés bajo tensión.%LINEBREAK%Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra blanca [1 %BANKLEFT%], [1 %STRAIGHT%] o [1 %BANKRIGHT%]."""
        '"Dutch" Vander':
-           display_name: """„Dutch” Vander"""
+           display_name: """„Dutch“ Vander"""
            text: """Después de que realices la acción %LOCK%, puedes elegir 1 nave aliada que tengas a alcance 1-3. Esa nave puede obtener un Blanco fijado sobre el objeto que acabas de fijar como blanco, ignorando las restricciones por alcance."""
        '"Echo"':
-           display_name: """„Eco”"""
+           display_name: """„Eco“"""
            text: """Mientras desactivas el camuflaje, debes utilizar la plantilla [2 %BANKLEFT%] o [2 %BANKRIGHT%] en vez de la plantilla [2 %STRAIGHT%].%LINEBREAK%Matriz de estigio: Después de que desactives el camuflaje, puedes realizar una acción %EVADE%. Al comienzo de la fase Final, puedes gastar 1 ficha de Evasión para recibir 1 ficha de Camuflaje."""
        '"Howlrunner"':
-           display_name: """„Aullador Veloz”"""
+           display_name: """„Aullador Veloz“"""
            text: """Mientras una nave aliada que tienes a alcance 0-1 efectúa un ataque principal, esa nave puede volver a tirar 1 dado de ataque."""
        '"Leebo"':
-           display_name: """„Leebo”"""
+           display_name: """„Leebo“"""
            text: """Después de que te defiendas o efectúes un ataque, si gastaste una ficha de Cálculos, recibes 1 ficha de Cálculos.%LINEBREAK%Punto ciego en los sensores: Mientras efectúas un ataque principal a alcance de ataque 0-1, no apliques el modificador por alcance 0-1 y tira 1 dado de ataque menos."""
        '"Mauler" Mithel':
-           display_name: """„Mutilador” Mithel"""
+           display_name: """„Mutilador“ Mithel"""
            text: """Mientras efectúas un ataque a alcance de ataque 1, tira 1 dado de ataque adicional."""
        '"Night Beast"':
-           display_name: """„Bestia Nocturna”"""
+           display_name: """„Bestia Nocturna“"""
            text: """Después de que ejecutes completamente una maniobra azul, puedes realizar una acción %FOCUS%."""
        '"Pure Sabacc"':
-           display_name: """„Sabacc Puro”"""
+           display_name: """„Sabacc Puro“"""
            text: """Mientras efectúas un ataque, si tienes 1 o menos cartas de Daño, puedes tirar 1 dado de ataque adicional.%LINEBREAK%Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra [1 %BANKLEFT%], [1 %STRAIGHT%] o [1 %BANKRIGHT%] de color blanco."""
        '"Redline"':
-           display_name: """„Velocidad Terminal”"""
+           display_name: """„Velocidad Terminal“"""
            text: """Puedes mantener hasta 2 Blancos fijados.%LINEBREAK%Después de que realices una acción, puedes obtener un Blanco fijado."""
        '"Scourge" Skutu':
-           display_name: """„Azote” Skutu"""
+           display_name: """„Azote“ Skutu"""
            text: """Mientras efectúas un ataque contra un defensor situado en tu %BULLSEYEARC%, tira 1 dado de ataque adicional."""
        '"Vizier"':
-           display_name: """„Visir”"""
+           display_name: """„Visir“"""
            text: """<smallbody>Después de que ejecutes completamente una maniobra de velocidad 1 utilizando la capacidad <strong>Alerones adaptativos</strong> de tu nave, puedes realizar una acción %COORDINATE%. Si lo haces, omite tu paso de “Realizar una acción”.</smallbody>%LINEBREAK%<sasmall><strong>Alerones adaptativos:</strong> Antes de revelar tu selector, si no estás bajo tensión, <b>debes</b> ejecutar una maniobra [1&nbsp;%BANKLEFT%], [1&nbsp;%STRAIGHT%] o [1&nbsp;%BANKRIGHT%] blanca.</sasmall>"""
        '"Wampa"':
-           display_name: """„Wampa”"""
+           display_name: """„Wampa“"""
            text: """Mientras efectúas un ataque, puedes gastar 1 %CHARGE% para tirar 1 dado de ataque adicional.%LINEBREAK%Después de que te defiendas, pierdes 1 %CHARGE%."""
        '"Whisper"':
-           display_name: """„Susurro”"""
+           display_name: """„Susurro“"""
            text: """Después de que efectúes un ataque que impacte, recibes 1 ficha de Evasión.%LINEBREAK%Matriz de estigio: Después de que desactives el camuflaje, puedes realizar una acción %EVADE%. Al comienzo de la fase Final, puedes gastar 1 ficha de Evasión para recibir 1 ficha de Camuflaje."""
        '"Zeb" Orrelios':
-           display_name: """„Zeb” Orrelios"""
+           display_name: """„Zeb“ Orrelios"""
            text: """Mientras te defiendes, los resultados %CRIT% se neutralizan antes que los resultados %HIT%.%LINEBREAK%Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal %FRONTARC% o %TURRET%, puede efectuar un ataque principal %REARARC% adicional."""
        '"Zeb" Orrelios (Sheathipede)':
-           display_name: """„Zeb” Orrelios (Sheathipede)"""
+           display_name: """„Zeb“ Orrelios (Sheathipede)"""
            text: """Mientras te defiendes, los resultados %CRIT% se neutralizan antes que los resultados %HIT%.%LINEBREAK%Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere %COORDINATE%. Antes de que tu nave nodriza se active, puede realizar una acción %COORDINATE%."""
        '"Zeb" Orrelios (TIE Fighter)':
-           display_name: """„Zeb” Orrelios (TIE Fighter)"""
+           display_name: """„Zeb“ Orrelios (TIE Fighter)"""
            text: """Mientras te defiendes, los resultados %CRIT% se neutralizan antes que los resultados %HIT%."""
 
 
@@ -1468,16 +1468,16 @@ exportObj.cardLoaders['Español'] = () ->
            display_name: """Zuckuss"""
            text: """<i>Sólo Escoria</i>%LINEBREAK%Mientras efectúas un ataque, si no estás bajo tensión, puedes elegir 1 dado de defensa y recibir 1 ficha de Tensión. Si lo haces, el defensor debe volver a tirar ese dado."""
        '"Chopper" (Crew)':
-           display_name: """„Chopper” (Crew)"""
+           display_name: """„Chopper“ (Crew)"""
            text: """<i>Sólo Rebelde</i>%LINEBREAK%Durante el paso de “Realizar una acción”, puedes realizar 1 acción, incluso aunque estés bajo tensión. Después de que realices una acción mientras estás bajo tensión, sufres 1 de daño %HIT% a menos que expongas 1 de tus cartas de Daño."""
        '"Chopper" (Astromech)':
-           display_name: """„Chopper” (Astromech)"""
+           display_name: """„Chopper“ (Astromech)"""
            text: """<i>Sólo Rebelde</i>%LINEBREAK%<strong>Acción:</strong> Gasta 1&nbsp;%CHARGE% no recurrente de otra carta de Mejora que tengas equipada para recuperar 1 escudo.%LINEBREAK%<strong>Acción:</strong> Gasta 2 escudos para recuperar 1&nbsp;%CHARGE% no recurrente sobre una mejora que tengas equipada."""
        '"Genius"':
-           display_name: """„Genio”"""
+           display_name: """„Genio“"""
            text: """<i>Sólo Escoria</i>%LINEBREAK%Después de que ejecutes completamente una maniobra, si no has soltado ni lanzado ningún dispositivo en esta ronda, puedes soltar 1 bomba."""
        '"Zeb" Orrelios':
-           display_name: """„Zeb” Orrelios"""
+           display_name: """„Zeb“ Orrelios"""
            text: """<i>Sólo Rebelde</i>%LINEBREAK%Eres capaz de efectuar ataques principales a alcance 0. Las naves enemigas que tengas a alcance 0 son capaces de efectuar ataques principales contra ti."""
 
 


### PR DESCRIPTION
-Changed the quotation mark on pilots/crews with nicknames, as it seems was causing conflicts and the translation didn't appear. Using the DE solution on this.
-Fixed a typo in a </strong> tag and in the Optimized Prototype description.
-Translated "Planetary Sentinel" name. For some reason it's not translated on the oficial app.