### PR TITLE
Remove unused stuff

### DIFF
--- a/coffeescripts/browser.coffee
+++ b/coffeescripts/browser.coffee
@@ -7,7 +7,7 @@ exportObj = exports ? this
 
 # Assumes cards.js has been loaded
 
-TYPES = [ 'pilots', 'upgrades', 'modifications', 'titles' ]
+TYPES = [ 'pilots', 'upgrades', 'titles' ]
 
 byName = (a, b) ->
     a_name = a.name.toLowerCase().replace(/[^a-zA-Z0-9]/g, '')
@@ -179,7 +179,7 @@ class exportObj.CardBrowser
             else
                 @all_cards = @all_cards.concat ( { name: card_data.name, type: exportObj.translate(@language, 'singular', type), data: card_data, orig_type: exportObj.translate('English', 'singular', type) } for card_name, card_data of exportObj[type] )
 
-        @types = (exportObj.translate(@language, 'types', type) for type in [ 'Pilot', 'Modification', 'Title' ])
+        @types = (exportObj.translate(@language, 'types', type) for type in [ 'Pilot', 'Title' ])
         for card_name, card_data of exportObj.upgrades
             upgrade_text = exportObj.translate @language, 'ui', 'upgradeHeader', card_data.slot
             @types.push upgrade_text if upgrade_text not in @types

--- a/coffeescripts/browser.coffee
+++ b/coffeescripts/browser.coffee
@@ -7,7 +7,7 @@ exportObj = exports ? this
 
 # Assumes cards.js has been loaded
 
-TYPES = [ 'pilots', 'upgrades', 'titles' ]
+TYPES = [ 'pilots', 'upgrades' ]
 
 byName = (a, b) ->
     a_name = a.name.toLowerCase().replace(/[^a-zA-Z0-9]/g, '')
@@ -179,7 +179,7 @@ class exportObj.CardBrowser
             else
                 @all_cards = @all_cards.concat ( { name: card_data.name, type: exportObj.translate(@language, 'singular', type), data: card_data, orig_type: exportObj.translate('English', 'singular', type) } for card_name, card_data of exportObj[type] )
 
-        @types = (exportObj.translate(@language, 'types', type) for type in [ 'Pilot', 'Title' ])
+        @types = (exportObj.translate(@language, 'types', type) for type in [ 'Pilot' ])
         for card_name, card_data of exportObj.upgrades
             upgrade_text = exportObj.translate @language, 'ui', 'upgradeHeader', card_data.slot
             @types.push upgrade_text if upgrade_text not in @types

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -7248,11 +7248,9 @@ exportObj.setupCardData = (basic_cards, pilot_translations, upgrade_translations
     exportObj.expansions = {}
 
     exportObj.pilotsById = {}
-    exportObj.pilotsByLocalizedName = {}
     for pilot_name, pilot of exportObj.pilots
         exportObj.fixIcons pilot
         exportObj.pilotsById[pilot.id] = pilot
-        exportObj.pilotsByLocalizedName[pilot.name] = pilot
         for source in pilot.sources
             exportObj.expansions[source] = 1 if source not of exportObj.expansions
     if Object.keys(exportObj.pilotsById).length != Object.keys(exportObj.pilots).length
@@ -7271,11 +7269,9 @@ exportObj.setupCardData = (basic_cards, pilot_translations, upgrade_translations
         
 
     exportObj.upgradesById = {}
-    exportObj.upgradesByLocalizedName = {}
     for upgrade_name, upgrade of exportObj.upgrades
         exportObj.fixIcons upgrade
         exportObj.upgradesById[upgrade.id] = upgrade
-        exportObj.upgradesByLocalizedName[upgrade.name] = upgrade
         for source in upgrade.sources
             exportObj.expansions[source] = 1 if source not of exportObj.expansions
     if Object.keys(exportObj.upgradesById).length != Object.keys(exportObj.upgrades).length
@@ -7290,7 +7286,6 @@ exportObj.setupCardData = (basic_cards, pilot_translations, upgrade_translations
         (exportObj.upgradesBySlotUniqueName[upgrade.slot] ?= {})[upgrade.canonical_name.getXWSBaseName()] = upgrade
 
     exportObj.modificationsById = {}
-    exportObj.modificationsByLocalizedName = {}
     for modification_name, modification of exportObj.modifications
         exportObj.fixIcons modification
         # Modifications cannot be added to huge ships unless specifically allowed
@@ -7301,7 +7296,6 @@ exportObj.setupCardData = (basic_cards, pilot_translations, upgrade_translations
             modification.restriction_func = (ship) ->
                 not (ship.data.huge ? false)
         exportObj.modificationsById[modification.id] = modification
-        exportObj.modificationsByLocalizedName[modification.name] = modification
         for source in modification.sources
             exportObj.expansions[source] = 1 if source not of exportObj.expansions
     if Object.keys(exportObj.modificationsById).length != Object.keys(exportObj.modifications).length
@@ -7314,11 +7308,9 @@ exportObj.setupCardData = (basic_cards, pilot_translations, upgrade_translations
         (exportObj.modificationsByUniqueName ?= {})[modification.canonical_name.getXWSBaseName()] = modification
 
     exportObj.titlesById = {}
-    exportObj.titlesByLocalizedName = {}
     for title_name, title of exportObj.titles
         exportObj.fixIcons title
         exportObj.titlesById[title.id] = title
-        exportObj.titlesByLocalizedName[title.name] = title
         for source in title.sources
             exportObj.expansions[source] = 1 if source not of exportObj.expansions
     if Object.keys(exportObj.titlesById).length != Object.keys(exportObj.titles).length

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -7177,9 +7177,7 @@ exportObj.setupCardData = (basic_cards, pilot_translations, upgrade_translations
     for pilot_data in basic_cards.pilotsById
         unless pilot_data.skip?
             pilot_data.sources = []
-            pilot_data.english_name = pilot_data.name
-            pilot_data.english_ship = pilot_data.ship
-            pilot_data.canonical_name = pilot_data.english_name.canonicalize() unless pilot_data.canonical_name?
+            pilot_data.canonical_name = pilot_data.name.canonicalize() unless pilot_data.canonical_name?
             exportObj.pilots[pilot_data.name] = pilot_data
     # pilot_name is the English version here as it's the common index into
     # basic card info
@@ -7188,37 +7186,32 @@ exportObj.setupCardData = (basic_cards, pilot_translations, upgrade_translations
     for upgrade_data in basic_cards.upgradesById
         unless upgrade_data.skip?
             upgrade_data.sources = []
-            upgrade_data.english_name = upgrade_data.name
-            upgrade_data.canonical_name = upgrade_data.english_name.canonicalize() unless upgrade_data.canonical_name?
+            upgrade_data.canonical_name = upgrade_data.name.canonicalize() unless upgrade_data.canonical_name?
             exportObj.upgrades[upgrade_data.name] = upgrade_data
 
     exportObj.modifications = {}
     for modification_data in basic_cards.modificationsById
         unless modification_data.skip?
             modification_data.sources = []
-            modification_data.english_name = modification_data.name
-            modification_data.canonical_name = modification_data.english_name.canonicalize() unless modification_data.canonical_name?
+            modification_data.canonical_name = modification_data.name.canonicalize() unless modification_data.canonical_name?
             exportObj.modifications[modification_data.name] = modification_data
 
     exportObj.titles = {}
     for title_data in basic_cards.titlesById
         unless title_data.skip?
             title_data.sources = []
-            title_data.english_name = title_data.name
-            title_data.canonical_name = title_data.english_name.canonicalize() unless title_data.canonical_name?
+            title_data.canonical_name = title_data.name.canonicalize() unless title_data.canonical_name?
             exportObj.titles[title_data.name] = title_data
 
     exportObj.conditions = {}
     for condition_data in basic_cards.conditionsById
         unless condition_data.skip?
             condition_data.sources = []
-            condition_data.english_name = condition_data.name
-            condition_data.canonical_name = condition_data.english_name.canonicalize() unless condition_data.canonical_name?
+            condition_data.canonical_name = condition_data.name.canonicalize() unless condition_data.canonical_name?
             exportObj.conditions[condition_data.name] = condition_data
 
     for ship_name, ship_data of basic_cards.ships
-        ship_data.english_name ?= ship_name
-        ship_data.canonical_name ?= ship_data.english_name.canonicalize()
+        ship_data.canonical_name ?= ship_data.name.canonicalize()
         ship_data.sources = []
 
     # Set sources from manifest
@@ -7477,15 +7470,10 @@ exportObj.fixIcons = (data) ->
             
 exportObj.canonicalizeShipNames = (card_data) ->
     for ship_name, ship_data of card_data.ships
-        ship_data.english_name = ship_name
-        ship_data.canonical_name ?= ship_data.english_name.canonicalize()
+        ship_data.canonical_name ?= ship_data.name.canonicalize()
 
-exportObj.renameShip = (english_name, new_name) ->
-    # exportObj.ships[new_name] = exportObj.ships[english_name]
-    # exportObj.ships[new_name].name = new_name
-    # exportObj.ships[new_name].english_name = english_name
-    exportObj.ships[english_name].display_name = new_name
-    # delete exportObj.ships[english_name]
+exportObj.renameShip = (name, new_name) ->
+    exportObj.ships[name].display_name = new_name
 
 exportObj.randomizer = (faction_name, points) ->
     shiplistmaster = exportObj.basicCardData #export ship database

--- a/coffeescripts/cards-de.coffee
+++ b/coffeescripts/cards-de.coffee
@@ -1802,7 +1802,5 @@ exportObj.cardLoaders.Deutsch = () ->
            text: '''(Mine Token) - After a ship overlaps or moves through this device, it detonates. When this device detonates, the ship suffers 1 %HIT% damage and gains 3 ion tokens.'''
         'Proximity Mine':
            text: '''(Mine Token) - After a ship overlaps or moves through this device, it detonates. When this device detonates, that ship rolls 2 attack dice. That ship then suffers 1 %HIT% plus 1 %HIT%/%CRIT% damage for each matching result.'''
-
-    title_translations =
             
-    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, title_translations, 
+    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations,  

--- a/coffeescripts/cards-de.coffee
+++ b/coffeescripts/cards-de.coffee
@@ -1802,9 +1802,7 @@ exportObj.cardLoaders.Deutsch = () ->
            text: '''(Mine Token) - After a ship overlaps or moves through this device, it detonates. When this device detonates, the ship suffers 1 %HIT% damage and gains 3 ion tokens.'''
         'Proximity Mine':
            text: '''(Mine Token) - After a ship overlaps or moves through this device, it detonates. When this device detonates, that ship rolls 2 attack dice. That ship then suffers 1 %HIT% plus 1 %HIT%/%CRIT% damage for each matching result.'''
-            
-    modification_translations =
 
     title_translations =
             
-    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, modification_translations, title_translations, 
+    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, title_translations, 

--- a/coffeescripts/cards-en.coffee
+++ b/coffeescripts/cards-en.coffee
@@ -1067,7 +1067,5 @@ exportObj.cardLoaders.English = () ->
            text: '''(Mine Token) - After a ship overlaps or moves through this device, it detonates. When this device detonates, the ship suffers 1 %HIT% damage and gains 3 ion tokens.'''
         'Proximity Mine':
            text: '''(Mine Token) - After a ship overlaps or moves through this device, it detonates. When this device detonates, that ship rolls 2 attack dice. That ship then suffers 1 %HIT% plus 1 %HIT%/%CRIT% damage for each matching result.'''
-
-    title_translations =
             
-    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, title_translations
+    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations

--- a/coffeescripts/cards-en.coffee
+++ b/coffeescripts/cards-en.coffee
@@ -1067,9 +1067,7 @@ exportObj.cardLoaders.English = () ->
            text: '''(Mine Token) - After a ship overlaps or moves through this device, it detonates. When this device detonates, the ship suffers 1 %HIT% damage and gains 3 ion tokens.'''
         'Proximity Mine':
            text: '''(Mine Token) - After a ship overlaps or moves through this device, it detonates. When this device detonates, that ship rolls 2 attack dice. That ship then suffers 1 %HIT% plus 1 %HIT%/%CRIT% damage for each matching result.'''
-            
-    modification_translations =
 
     title_translations =
             
-    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, modification_translations, title_translations
+    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, title_translations

--- a/coffeescripts/cards-es.coffee
+++ b/coffeescripts/cards-es.coffee
@@ -1556,6 +1556,4 @@ exportObj.cardLoaders['Español'] = () ->
            display_name: """Mina de proximidad"""
            text: '''(Ficha de Mina) - Después de que una nave se solape con este dispositivo o pase a través de él, este dispositivo se detona.%LINEBREAK%Cuando este dispositivo se detona, la nave que provocó su detonación tira 2 dados de ataque. Esa nave sufre a continuación 1 de daño %HIT% además de 1 de daño %HIT%/%CRIT% por cada resultado equivalente obtenido en la tirada.'''
 
-    title_translations =
-
-    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, title_translations,
+    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, 

--- a/coffeescripts/cards-es.coffee
+++ b/coffeescripts/cards-es.coffee
@@ -1556,8 +1556,6 @@ exportObj.cardLoaders['Español'] = () ->
            display_name: """Mina de proximidad"""
            text: '''(Ficha de Mina) - Después de que una nave se solape con este dispositivo o pase a través de él, este dispositivo se detona.%LINEBREAK%Cuando este dispositivo se detona, la nave que provocó su detonación tira 2 dados de ataque. Esa nave sufre a continuación 1 de daño %HIT% además de 1 de daño %HIT%/%CRIT% por cada resultado equivalente obtenido en la tirada.'''
 
-    modification_translations =
-
     title_translations =
 
-    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, modification_translations, title_translations,
+    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, title_translations,

--- a/coffeescripts/cards-es.coffee
+++ b/coffeescripts/cards-es.coffee
@@ -879,67 +879,67 @@ exportObj.cardLoaders['Español'] = () ->
         "Zuckuss":
            display_name: """Zuckuss"""
            text: """Mientras efectúas un ataque principal, puedes tirar 1 dado de ataque adicional. Si lo haces, el defensor tira 1 dado de defensa adicional."""
-       '"Chopper"':
+        '"Chopper"':
            display_name: """„Chopper“"""
            text: """Al comienzo de la fase de Enfrentamiento, toda nave enemiga que tengas a alcance 0 recibe 2 fichas de Interferencia.%LINEBREAK%Cañón de cola: Mientras tienes una nave acoplada, posees un armamento principal %REARARC% con un valor de Ataque igual al del armamento principal %FRONTARC% de tu nave acoplada."""
-       '"Countdown"':
+        '"Countdown"':
            display_name: """„Cuenta Atrás“"""
            text: """Mientras te defiendes, después del paso de “Neutralizar los resultados”, puedes sufrir 1 de daño %HIT% y recibir 1 ficha de Tensión. Si lo haces, anula todos los resultados de los dados.%LINEBREAK%Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra [1 %BANKLEFT%], [1 %STRAIGHT%] o [1 %BANKRIGHT%] de color blanco."""
-       '"Deathfire"':
+        '"Deathfire"':
            display_name: """„Muerte Ígnea“"""
            text: """Después de que seas destruido, antes de ser retirado de la zona de juego, puedes efectuar un ataque y soltar o lanzar 1 dispositivo. %LINEBREAK%Bombardero ágil: Si vas a soltar un dispositivo utilizando una plantilla %STRAIGHT%, en vez de esa plantilla puedes utilizar una plantilla %BANKLEFT% o %BANKRIGHT% con la misma velocidad."""
-       '"Deathrain"':
+        '"Deathrain"':
            display_name: """„Lluvia de Muerte“"""
            text: """Después de que sueltes o lances un dispositivo, puedes realizar una acción."""
-       '"Double Edge"':
+        '"Double Edge"':
            display_name: """„Doble Filo“"""
            text: """Después de que efectúes un ataque %TURRET% o %MISSILE% que falle, puedes realizar un ataque adicional utilizando un arma diferente."""
-       '"Duchess"':
+        '"Duchess"':
            display_name: """„Duquesa“"""
            text: """Puedes elegir no utilizar tus alerones adaptativos.%LINEBREAK%Puedes utilizar tus alerones adaptativos incluso aunque estés bajo tensión.%LINEBREAK%Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra blanca [1 %BANKLEFT%], [1 %STRAIGHT%] o [1 %BANKRIGHT%]."""
-       '"Dutch" Vander':
+        '"Dutch" Vander':
            display_name: """„Dutch“ Vander"""
            text: """Después de que realices la acción %LOCK%, puedes elegir 1 nave aliada que tengas a alcance 1-3. Esa nave puede obtener un Blanco fijado sobre el objeto que acabas de fijar como blanco, ignorando las restricciones por alcance."""
-       '"Echo"':
+        '"Echo"':
            display_name: """„Eco“"""
            text: """Mientras desactivas el camuflaje, debes utilizar la plantilla [2 %BANKLEFT%] o [2 %BANKRIGHT%] en vez de la plantilla [2 %STRAIGHT%].%LINEBREAK%Matriz de estigio: Después de que desactives el camuflaje, puedes realizar una acción %EVADE%. Al comienzo de la fase Final, puedes gastar 1 ficha de Evasión para recibir 1 ficha de Camuflaje."""
-       '"Howlrunner"':
+        '"Howlrunner"':
            display_name: """„Aullador Veloz“"""
            text: """Mientras una nave aliada que tienes a alcance 0-1 efectúa un ataque principal, esa nave puede volver a tirar 1 dado de ataque."""
-       '"Leebo"':
+        '"Leebo"':
            display_name: """„Leebo“"""
            text: """Después de que te defiendas o efectúes un ataque, si gastaste una ficha de Cálculos, recibes 1 ficha de Cálculos.%LINEBREAK%Punto ciego en los sensores: Mientras efectúas un ataque principal a alcance de ataque 0-1, no apliques el modificador por alcance 0-1 y tira 1 dado de ataque menos."""
-       '"Mauler" Mithel':
+        '"Mauler" Mithel':
            display_name: """„Mutilador“ Mithel"""
            text: """Mientras efectúas un ataque a alcance de ataque 1, tira 1 dado de ataque adicional."""
-       '"Night Beast"':
+        '"Night Beast"':
            display_name: """„Bestia Nocturna“"""
            text: """Después de que ejecutes completamente una maniobra azul, puedes realizar una acción %FOCUS%."""
-       '"Pure Sabacc"':
+        '"Pure Sabacc"':
            display_name: """„Sabacc Puro“"""
            text: """Mientras efectúas un ataque, si tienes 1 o menos cartas de Daño, puedes tirar 1 dado de ataque adicional.%LINEBREAK%Alerones adaptativos: Antes de que reveles tu selector, si no estás bajo tensión, debes ejecutar una maniobra [1 %BANKLEFT%], [1 %STRAIGHT%] o [1 %BANKRIGHT%] de color blanco."""
-       '"Redline"':
+        '"Redline"':
            display_name: """„Velocidad Terminal“"""
            text: """Puedes mantener hasta 2 Blancos fijados.%LINEBREAK%Después de que realices una acción, puedes obtener un Blanco fijado."""
-       '"Scourge" Skutu':
+        '"Scourge" Skutu':
            display_name: """„Azote“ Skutu"""
            text: """Mientras efectúas un ataque contra un defensor situado en tu %BULLSEYEARC%, tira 1 dado de ataque adicional."""
-       '"Vizier"':
+        '"Vizier"':
            display_name: """„Visir“"""
            text: """<smallbody>Después de que ejecutes completamente una maniobra de velocidad 1 utilizando la capacidad <strong>Alerones adaptativos</strong> de tu nave, puedes realizar una acción %COORDINATE%. Si lo haces, omite tu paso de “Realizar una acción”.</smallbody>%LINEBREAK%<sasmall><strong>Alerones adaptativos:</strong> Antes de revelar tu selector, si no estás bajo tensión, <b>debes</b> ejecutar una maniobra [1&nbsp;%BANKLEFT%], [1&nbsp;%STRAIGHT%] o [1&nbsp;%BANKRIGHT%] blanca.</sasmall>"""
-       '"Wampa"':
+        '"Wampa"':
            display_name: """„Wampa“"""
            text: """Mientras efectúas un ataque, puedes gastar 1 %CHARGE% para tirar 1 dado de ataque adicional.%LINEBREAK%Después de que te defiendas, pierdes 1 %CHARGE%."""
-       '"Whisper"':
+        '"Whisper"':
            display_name: """„Susurro“"""
            text: """Después de que efectúes un ataque que impacte, recibes 1 ficha de Evasión.%LINEBREAK%Matriz de estigio: Después de que desactives el camuflaje, puedes realizar una acción %EVADE%. Al comienzo de la fase Final, puedes gastar 1 ficha de Evasión para recibir 1 ficha de Camuflaje."""
-       '"Zeb" Orrelios':
+        '"Zeb" Orrelios':
            display_name: """„Zeb“ Orrelios"""
            text: """Mientras te defiendes, los resultados %CRIT% se neutralizan antes que los resultados %HIT%.%LINEBREAK%Armas preparadas: Mientras estás acoplado, después de que tu nave nodriza efectúe un ataque principal %FRONTARC% o %TURRET%, puede efectuar un ataque principal %REARARC% adicional."""
-       '"Zeb" Orrelios (Sheathipede)':
+        '"Zeb" Orrelios (Sheathipede)':
            display_name: """„Zeb“ Orrelios (Sheathipede)"""
            text: """Mientras te defiendes, los resultados %CRIT% se neutralizan antes que los resultados %HIT%.%LINEBREAK%Lanzadera de comunicaciones: Mientras estás acoplado, tu nave nodriza adquiere %COORDINATE%. Antes de que tu nave nodriza se active, puede realizar una acción %COORDINATE%."""
-       '"Zeb" Orrelios (TIE Fighter)':
+        '"Zeb" Orrelios (TIE Fighter)':
            display_name: """„Zeb“ Orrelios (TIE Fighter)"""
            text: """Mientras te defiendes, los resultados %CRIT% se neutralizan antes que los resultados %HIT%."""
 

--- a/coffeescripts/cards-fr.coffee
+++ b/coffeescripts/cards-fr.coffee
@@ -1223,7 +1223,5 @@ exportObj.cardLoaders['Français'] = () ->
         'Proximity Mine':
            display_name: 'Mine de proximité'
            text: '''(Mine) - Après qu’un vaisseau a chevauché ou s’est déplacé à travers cet engin, ce dernier explose. Lorsque cet engin explose, le vaisseau lance 2 dés d’attaque. Puis ce vaisseau subit 1 dégât %HIT% plus 1 dégât %HIT%/%CRIT% pour chaque résultat correspondant obtenu.'''
-
-    title_translations =
-            
-    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, title_translations
+       
+    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, 

--- a/coffeescripts/cards-fr.coffee
+++ b/coffeescripts/cards-fr.coffee
@@ -1223,9 +1223,7 @@ exportObj.cardLoaders['Français'] = () ->
         'Proximity Mine':
            display_name: 'Mine de proximité'
            text: '''(Mine) - Après qu’un vaisseau a chevauché ou s’est déplacé à travers cet engin, ce dernier explose. Lorsque cet engin explose, le vaisseau lance 2 dés d’attaque. Puis ce vaisseau subit 1 dégât %HIT% plus 1 dégât %HIT%/%CRIT% pour chaque résultat correspondant obtenu.'''
-            
-    modification_translations =
 
     title_translations =
             
-    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, modification_translations, title_translations
+    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, title_translations

--- a/coffeescripts/cards-hu.coffee
+++ b/coffeescripts/cards-hu.coffee
@@ -1126,7 +1126,5 @@ exportObj.cardLoaders.Magyar = () ->
            text: '''(Akna jelző) - Miután egy hajó átmozog vagy átfedésbe kerül ezzel az eszközzel, az felrobban. Amikor ez az eszköz felrobban, a hajó elszenved 1 %HIT% sérülést és kap 3 ion jelzőt.'''
         'Proximity Mine':
            text: '''(Akna jelző) - Miután egy hajó átmozog vagy átfedésbe kerül ezzel az eszközzel,  az felrobban. Amikor ez az eszköz felrobban, a hajó dob 2 támadókockával, aztán elszenved 1 %HIT%, valamint a dobott eremény szerint 1-1 %HIT%/%CRIT% sérülést.'''
-            
-    title_translations =
-            
-    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, title_translations, 
+                        
+    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations,  

--- a/coffeescripts/cards-hu.coffee
+++ b/coffeescripts/cards-hu.coffee
@@ -1127,8 +1127,6 @@ exportObj.cardLoaders.Magyar = () ->
         'Proximity Mine':
            text: '''(Akna jelző) - Miután egy hajó átmozog vagy átfedésbe kerül ezzel az eszközzel,  az felrobban. Amikor ez az eszköz felrobban, a hajó dob 2 támadókockával, aztán elszenved 1 %HIT%, valamint a dobott eremény szerint 1-1 %HIT%/%CRIT% sérülést.'''
             
-    modification_translations =
-
     title_translations =
             
-    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, modification_translations, title_translations, 
+    exportObj.setupCardData basic_cards, pilot_translations, upgrade_translations, condition_translations, title_translations, 

--- a/coffeescripts/manifest.coffee
+++ b/coffeescripts/manifest.coffee
@@ -3498,32 +3498,6 @@ exportObj.manifestByExpansion =
 
 
 class exportObj.Collection
-    # collection = new exportObj.Collection
-    #   expansions:
-    #     "Core": 2
-    #     "TIE Fighter Expansion Pack": 4
-    #     "B-Wing Expansion Pack": 2
-    #   singletons:
-    #     ship:
-    #       "T-70 X-Wing": 1
-    #     pilot:
-    #       "Academy Pilot": 16
-    #     upgrade:
-    #       "C-3PO": 4
-    #       "Gunner": 5
-    #     title:
-    #       "TIE/x1": 1
-    #
-    # # or
-    #
-    # collection = exportObj.Collection.load(backend)
-    #
-    # collection.use "pilot", "Red Squadron Pilot"
-    # collection.use "upgrade", "R2-D2"
-    # collection.use "upgrade", "Ion Pulse Missiles" # returns false
-    #
-    # collection.release "pilot", "Red Squadron Pilot"
-    # collection.release "pilot", "Sigma Squadron Pilot" # returns false
 
     constructor: (args) ->
         @expansions = args.expansions ? {}
@@ -3773,26 +3747,6 @@ class exportObj.Collection
             input.closest('div').css 'background-color', @countToBackgroundColor(input.val())
             $(row).find('.upgrade-name').data 'name', expansion
             upgradecollection_content.append row
-
-        ###titlecollection_content = $ @modal.find('.collection-title-content')
-        for title in singletonsByType.title
-            count = parseInt(@singletons.title?[title] ? 0)
-            row = $.parseHTML $.trim """
-                <div class="row-fluid">
-                    <div class="span12">
-                        <label>
-                            <input class="singleton-count" type="number" size="3" value="#{count}" />
-                            <span class="title-name">#{title}</span>
-                        </label>
-                    </div>
-                </div>
-            """
-            input = $ $(row).find('input')
-            input.data 'singletonType', 'title'
-            input.data 'singletonName', title
-            input.closest('div').css 'background-color', @countToBackgroundColor(input.val())
-            $(row).find('.title-name').data 'name', expansion
-            titlecollection_content.append row###
 
     destroyUI: ->
         @modal.modal 'hide'

--- a/coffeescripts/manifest.coffee
+++ b/coffeescripts/manifest.coffee
@@ -3712,7 +3712,7 @@ class exportObj.Collection
             input = $ $(row).find('input')
             input.data 'expansion', expansion
             input.closest('div').css 'background-color', @countToBackgroundColor(input.val())
-            $(row).find('.expansion-name').data 'english_name', expansion
+            $(row).find('.expansion-name').data 'name', expansion
             if expansion != 'Loose Ships'
                 collection_content.append row
 
@@ -3733,7 +3733,7 @@ class exportObj.Collection
             input.data 'singletonType', 'ship'
             input.data 'singletonName', ship
             input.closest('div').css 'background-color', @countToBackgroundColor(input.val())
-            $(row).find('.ship-name').data 'english_name', expansion
+            $(row).find('.ship-name').data 'name', expansion
             shipcollection_content.append row
 
         pilotcollection_content = $ @modal.find('.collection-pilot-content')
@@ -3753,7 +3753,7 @@ class exportObj.Collection
             input.data 'singletonType', 'pilot'
             input.data 'singletonName', pilot
             input.closest('div').css 'background-color', @countToBackgroundColor(input.val())
-            $(row).find('.pilot-name').data 'english_name', expansion
+            $(row).find('.pilot-name').data 'name', expansion
             pilotcollection_content.append row
 
         upgradecollection_content = $ @modal.find('.collection-upgrade-content')
@@ -3773,7 +3773,7 @@ class exportObj.Collection
             input.data 'singletonType', 'upgrade'
             input.data 'singletonName', upgrade
             input.closest('div').css 'background-color', @countToBackgroundColor(input.val())
-            $(row).find('.upgrade-name').data 'english_name', expansion
+            $(row).find('.upgrade-name').data 'name', expansion
             upgradecollection_content.append row
 
         ###modificationcollection_content = $ @modal.find('.collection-modification-content')
@@ -3793,7 +3793,7 @@ class exportObj.Collection
             input.data 'singletonType', 'modification'
             input.data 'singletonName', modification
             input.closest('div').css 'background-color', @countToBackgroundColor(input.val())
-            $(row).find('.modification-name').data 'english_name', expansion
+            $(row).find('.modification-name').data 'name', expansion
             modificationcollection_content.append row ###
 
         ###titlecollection_content = $ @modal.find('.collection-title-content')
@@ -3813,7 +3813,7 @@ class exportObj.Collection
             input.data 'singletonType', 'title'
             input.data 'singletonName', title
             input.closest('div').css 'background-color', @countToBackgroundColor(input.val())
-            $(row).find('.title-name').data 'english_name', expansion
+            $(row).find('.title-name').data 'name', expansion
             titlecollection_content.append row###
 
     destroyUI: ->
@@ -3886,6 +3886,6 @@ class exportObj.Collection
                 # console.log "language changed to #{language}"
                 do (language) =>
                     @modal.find('.expansion-name').each ->
-                        # console.log "translating #{$(this).text()} (#{$(this).data('english_name')}) to #{language}"
-                        $(this).text exportObj.translate language, 'sources', $(this).data('english_name')
+                        # console.log "translating #{$(this).text()} (#{$(this).data('name')}) to #{language}"
+                        $(this).text exportObj.translate language, 'sources', $(this).data('name')
                 @language = language

--- a/coffeescripts/manifest.coffee
+++ b/coffeescripts/manifest.coffee
@@ -3511,8 +3511,6 @@ class exportObj.Collection
     #     upgrade:
     #       "C-3PO": 4
     #       "Gunner": 5
-    #     modification:
-    #       "Engine Upgrade": 2
     #     title:
     #       "TIE/x1": 1
     #
@@ -3775,26 +3773,6 @@ class exportObj.Collection
             input.closest('div').css 'background-color', @countToBackgroundColor(input.val())
             $(row).find('.upgrade-name').data 'name', expansion
             upgradecollection_content.append row
-
-        ###modificationcollection_content = $ @modal.find('.collection-modification-content')
-        for modification in singletonsByType.modification
-            count = parseInt(@singletons.modification?[modification] ? 0)
-            row = $.parseHTML $.trim """
-                <div class="row-fluid">
-                    <div class="span12">
-                        <label>
-                            <input class="singleton-count" type="number" size="3" value="#{count}" />
-                            <span class="modification-name">#{modification}</span>
-                        </label>
-                    </div>
-                </div>
-            """
-            input = $ $(row).find('input')
-            input.data 'singletonType', 'modification'
-            input.data 'singletonName', modification
-            input.closest('div').css 'background-color', @countToBackgroundColor(input.val())
-            $(row).find('.modification-name').data 'name', expansion
-            modificationcollection_content.append row ###
 
         ###titlecollection_content = $ @modal.find('.collection-title-content')
         for title in singletonsByType.title

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -1350,7 +1350,7 @@ class exportObj.SquadBuilder
         # Returns data formatted for Select2
         limited_upgrades_in_use = (upgrade.data for upgrade in ship.upgrades when upgrade?.data?.limited?)
 
-        available_upgrades = (upgrade for upgrade_name, upgrade of exportObj.upgradesByLocalizedName when upgrade.slot == slot and ( @matcher(upgrade_name, term) or (upgrade.display_name and @matcher(upgrade.display_name, term)) ) and (not upgrade.ship? or @isShip(upgrade.ship, ship.data.name)) and (not upgrade.faction? or @isOurFaction(upgrade.faction)) and (not @isSecondEdition or exportObj.secondEditionCheck(upgrade)))
+        available_upgrades = (upgrade for upgrade_name, upgrade of exportObj.upgrades when upgrade.slot == slot and ( @matcher(upgrade_name, term) or (upgrade.display_name and @matcher(upgrade.display_name, term)) ) and (not upgrade.ship? or @isShip(upgrade.ship, ship.data.name)) and (not upgrade.faction? or @isOurFaction(upgrade.faction)) and (not @isSecondEdition or exportObj.secondEditionCheck(upgrade)))
 
         if filter_func != @dfl_filter_func
             available_upgrades = (upgrade for upgrade in available_upgrades when filter_func(upgrade))
@@ -1385,7 +1385,7 @@ class exportObj.SquadBuilder
         # Returns data formatted for Select2
         limited_modifications_in_use = (modification.data for modification in ship.modifications when modification?.data?.limited?)
 
-        available_modifications = (modification for modification_name, modification of exportObj.modificationsByLocalizedName when ( @matcher(modification_name, term) or (modification.display_name and @matcher(modification.display_name, term)) ) and (not modification.ship? or modification.ship == ship.data.name) and (not @isSecondEdition or exportObj.secondEditionCheck(modification)))
+        available_modifications = (modification for modification_name, modification of exportObj.modifications when ( @matcher(modification_name, term) or (modification.display_name and @matcher(modification.display_name, term)) ) and (not modification.ship? or modification.ship == ship.data.name) and (not @isSecondEdition or exportObj.secondEditionCheck(modification)))
 
         if filter_func != @dfl_filter_func
             available_modifications = (modification for modification in available_modifications when filter_func(modification))
@@ -1412,7 +1412,7 @@ class exportObj.SquadBuilder
         # Returns data formatted for Select2
         # Titles are no longer unique!
         limited_titles_in_use = (title.data for title in ship.titles when title?.data?.limited?)
-        available_titles = (title for title_name, title of exportObj.titlesByLocalizedName when (not title.ship? or title.ship == ship.data.name) and ( @matcher(title_name, term) or (title.display_name and @matcher(title.display_name, term))) )
+        available_titles = (title for title_name, title of exportObj.titles when (not title.ship? or title.ship == ship.data.name) and ( @matcher(title_name, term) or (title.display_name and @matcher(title.display_name, term))) )
 
         eligible_titles = (title for title_name, title of available_titles when (not title.unique? or (title not in @uniques_in_use['Title'] and title.canonical_name.getXWSBaseName() not in (t.canonical_name.getXWSBaseName() for t in @uniques_in_use['Title'])) or title.canonical_name.getXWSBaseName() == include_title?.canonical_name.getXWSBaseName()) and (not title.faction? or @isOurFaction(title.faction)) and (not (ship? and title.restriction_func?) or title.restriction_func ship) and title not in limited_titles_in_use)
 
@@ -2313,7 +2313,7 @@ class Ship
         @setPilot exportObj.pilotsById[parseInt id]
 
     setPilotByName: (name) ->
-        @setPilot exportObj.pilotsByLocalizedName[$.trim name]
+        @setPilot exportObj.pilots[$.trim name]
 
     setPilot: (new_pilot) ->
         if new_pilot != @pilot
@@ -3499,7 +3499,7 @@ class exportObj.Upgrade extends GenericAddon
         @slot = args.slot
         @type = 'Upgrade'
         @dataById = exportObj.upgradesById
-        @dataByName = exportObj.upgradesByLocalizedName
+        @dataByName = exportObj.upgrades
         @serialization_code = 'U'
 
         @setupSelector()
@@ -3542,7 +3542,7 @@ class exportObj.Title extends GenericAddon
         super args
         @type = 'Title'
         @dataById = exportObj.titlesById
-        @dataByName = exportObj.titlesByLocalizedName
+        @dataByName = exportObj.titles
         @serialization_code = 'T'
 
         @setupSelector()

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -1297,16 +1297,16 @@ class exportObj.SquadBuilder
                         if ship_data.display_name
                             ships.push
                                 id: ship_data.name
+                                name: ship_data.name
                                 display_name: ship_data.display_name
                                 text: ship_data.display_name
-                                english_name: ship_data.english_name
                                 canonical_name: ship_data.canonical_name
                                 xws: ship_data.xws
                         else                        
                             ships.push
                                 id: ship_data.name
+                                name: ship_data.name
                                 text: ship_data.name
-                                english_name: ship_data.english_name
                                 canonical_name: ship_data.canonical_name
                                 xws: ship_data.xws
         ships.sort exportObj.sortHelper
@@ -1322,7 +1322,7 @@ class exportObj.SquadBuilder
         # Re-add selected pilot
         if include_pilot? and include_pilot.unique? and (@matcher(include_pilot.name, term) or (include_pilot.display_name and @matcher(include_pilot.display_name, term)) )
             eligible_faction_pilots.push include_pilot
-        ({ id: pilot.id, text: "#{if pilot.display_name then pilot.display_name else pilot.name} (#{pilot.points})", points: pilot.points, ship: pilot.ship, english_name: pilot.english_name, disabled: pilot not in eligible_faction_pilots } for pilot in available_faction_pilots).sort exportObj.sortHelper
+        ({ id: pilot.id, text: "#{if pilot.display_name then pilot.display_name else pilot.name} (#{pilot.points})", points: pilot.points, ship: pilot.ship, name: pilot.name, display_name: pilot.display_name, disabled: pilot not in eligible_faction_pilots } for pilot in available_faction_pilots).sort exportObj.sortHelper
 
     dfl_filter_func = ->
         true
@@ -1373,7 +1373,7 @@ class exportObj.SquadBuilder
             # available_upgrades.push include_upgrade
             eligible_upgrades.push include_upgrade
 
-        retval = ({ id: upgrade.id, text: "#{if upgrade.display_name then upgrade.display_name else upgrade.name} (#{upgrade.points})", points: upgrade.points, english_name: upgrade.english_name, disabled: upgrade not in eligible_upgrades } for upgrade in available_upgrades).sort exportObj.sortHelper
+        retval = ({ id: upgrade.id, text: "#{if upgrade.display_name then upgrade.display_name else upgrade.name} (#{upgrade.points})", points: upgrade.points, name: upgrade.name, display_name: upgrade.display_name, disabled: upgrade not in eligible_upgrades } for upgrade in available_upgrades).sort exportObj.sortHelper
         
         # Possibly adjust the upgrade
         if this_upgrade_obj.adjustment_func?
@@ -1406,7 +1406,7 @@ class exportObj.SquadBuilder
         # Re-add selected modification
         if include_modification? and (((include_modification.unique? or include_modification.limited?) and ( @matcher(include_modification.name, term) or (include_modification.display_name and @matcher(include_modification.display_name, term)) ) ))# or current_mod_forcibly_removed)
             eligible_modifications.push include_modification
-        ({ id: modification.id, text: "#{if modification.display_name then modification.display_name else modification.name} (#{modification.points})", points: modification.points, english_name: modification.english_name, disabled: modification not in eligible_modifications } for modification in available_modifications).sort exportObj.sortHelper
+        ({ id: modification.id, text: "#{if modification.display_name then modification.display_name else modification.name} (#{modification.points})", points: modification.points, name: modification.name, display_name: modification.display_name, disabled: modification not in eligible_modifications } for modification in available_modifications).sort exportObj.sortHelper
 
     getAvailableTitlesIncluding: (ship, include_title, term='') ->
         # Returns data formatted for Select2
@@ -1419,7 +1419,7 @@ class exportObj.SquadBuilder
         # Re-add selected title
         if include_title? and (((include_title.unique? or include_title.limited?) and (@matcher(include_title.name, term) or (include_title.display_name and @matcher(include_title.display_name, term)) )))
             eligible_titles.push include_title
-        ({ id: title.id, text: "#{if title.display_name then title.display_name else title.name} (#{title.points})", points: title.points, english_name: title.english_name, disabled: title not in eligible_titles } for title in available_titles).sort exportObj.sortHelper
+        ({ id: title.id, text: "#{if title.display_name then title.display_name else title.name} (#{title.points})", points: title.points, name: title.name, display_name: title.display_name, disabled: title not in eligible_titles } for title in available_titles).sort exportObj.sortHelper
 
     # Converts a maneuver table for into an HTML table.
     getManeuverTableHTML: (maneuvers, baseManeuvers) ->
@@ -1565,8 +1565,8 @@ class exportObj.SquadBuilder
                 when 'Ship'
                     @info_container.find('.info-sources').text (exportObj.translate(@language, 'sources', source) for source in data.pilot.sources).sort().join(', ')
                     if @collection?.counts?
-                        ship_count = @collection.counts?.ship?[data.data.english_name] ? 0
-                        pilot_count = @collection.counts?.pilot?[data.pilot.english_name] ? 0
+                        ship_count = @collection.counts?.ship?[data.data.name] ? 0
+                        pilot_count = @collection.counts?.pilot?[data.pilot.name] ? 0
                         @info_container.find('.info-collection').text """You have #{ship_count} ship model#{if ship_count > 1 then 's' else ''} and #{pilot_count} pilot card#{if pilot_count > 1 then 's' else ''} in your collection."""
                     else
                         @info_container.find('.info-collection').text ''
@@ -1653,7 +1653,7 @@ class exportObj.SquadBuilder
                 when 'Pilot'
                     @info_container.find('.info-sources').text (exportObj.translate(@language, 'sources', source) for source in data.sources).sort().join(', ')
                     if @collection?.counts?
-                        pilot_count = @collection.counts?.pilot?[data.english_name] ? 0
+                        pilot_count = @collection.counts?.pilot?[data.name] ? 0
                         ship_count = @collection.counts.ship?[additional_opts.ship] ? 0
                         @info_container.find('.info-collection').text """You have #{ship_count} ship model#{if ship_count > 1 then 's' else ''} and #{pilot_count} pilot card#{if pilot_count > 1 then 's' else ''} in your collection."""
                     else
@@ -1737,7 +1737,7 @@ class exportObj.SquadBuilder
                 when 'Addon'
                     @info_container.find('.info-sources').text (exportObj.translate(@language, 'sources', source) for source in data.sources).sort().join(', ')
                     if @collection?.counts?
-                        addon_count = @collection.counts?[additional_opts.addon_type.toLowerCase()]?[data.english_name] ? 0
+                        addon_count = @collection.counts?[additional_opts.addon_type.toLowerCase()]?[data.name] ? 0
                         @info_container.find('.info-collection').text """You have #{addon_count} in your collection."""
                     else
                         @info_container.find('.info-collection').text ''
@@ -1951,25 +1951,25 @@ class exportObj.SquadBuilder
         for ship in @ships
             if ship.pilot?
                 # Try to get both the physical model and the pilot card.
-                ship_is_available = @collection.use('ship', ship.pilot.english_ship)
-                pilot_is_available = @collection.use('pilot', ship.pilot.english_name)
-                # console.log "#{@faction}: Ship #{ship.pilot.english_ship} available: #{ship_is_available}"
-                # console.log "#{@faction}: Pilot #{ship.pilot.english_name} available: #{pilot_is_available}"
+                ship_is_available = @collection.use('ship', ship.pilot.ship)
+                pilot_is_available = @collection.use('pilot', ship.pilot.name)
+                # console.log "#{@faction}: Ship #{ship.pilot.ship} available: #{ship_is_available}"
+                # console.log "#{@faction}: Pilot #{ship.pilot.name} available: #{pilot_is_available}"
                 validity = false unless ship_is_available and pilot_is_available
                 for upgrade in ship.upgrades
                     if upgrade.data?
-                        upgrade_is_available = @collection.use('upgrade', upgrade.data.english_name)
-                        # console.log "#{@faction}: Upgrade #{upgrade.data.english_name} available: #{upgrade_is_available}"
+                        upgrade_is_available = @collection.use('upgrade', upgrade.data.name)
+                        # console.log "#{@faction}: Upgrade #{upgrade.data.name} available: #{upgrade_is_available}"
                         validity = false unless upgrade_is_available
                 for modification in ship.modifications
                     if modification.data?
-                        modification_is_available = @collection.use('modification', modification.data.english_name)
-                        # console.log "#{@faction}: Modification #{modification.data.english_name} available: #{modification_is_available}"
+                        modification_is_available = @collection.use('modification', modification.data.name)
+                        # console.log "#{@faction}: Modification #{modification.data.name} available: #{modification_is_available}"
                         validity = false unless modification_is_available
                 for title in ship.titles
                     if title?.data?
-                        title_is_available = @collection.use('title', title.data.english_name)
-                        # console.log "#{@faction}: Title #{title.data.english_name} available: #{title_is_available}"
+                        title_is_available = @collection.use('title', title.data.name)
+                        # console.log "#{@faction}: Title #{title.data.name} available: #{title_is_available}"
                         validity = false unless title_is_available
         validity
 
@@ -2485,11 +2485,11 @@ class Ship
                     if @pilot? and obj.id == exportObj.ships[@pilot.ship].id
                         # Currently selected ship; mark as not in collection if it's neither
                         # on the shelf nor on the table
-                        unless (@builder.collection.checkShelf('ship', obj.english_name) or @builder.collection.checkTable('pilot', obj.english_name))
+                        unless (@builder.collection.checkShelf('ship', obj.name) or @builder.collection.checkTable('pilot', obj.name))
                             not_in_collection = true
                     else
                         # Not currently selected; check shelf only
-                        not_in_collection = not @builder.collection.checkShelf('ship', obj.english_name)
+                        not_in_collection = not @builder.collection.checkShelf('ship', obj.name)
                     if not_in_collection then 'select2-result-not-in-collection' else ''
                 else
                     ''
@@ -2516,11 +2516,11 @@ class Ship
                     if obj.id == @pilot?.id
                         # Currently selected pilot; mark as not in collection if it's neither
                         # on the shelf nor on the table
-                        unless (@builder.collection.checkShelf('pilot', obj.english_name) or @builder.collection.checkTable('pilot', obj.english_name))
+                        unless (@builder.collection.checkShelf('pilot', obj.name) or @builder.collection.checkTable('pilot', obj.name))
                             not_in_collection = true
                     else
                         # Not currently selected; check shelf only
-                        not_in_collection = not @builder.collection.checkShelf('pilot', obj.english_name)
+                        not_in_collection = not @builder.collection.checkShelf('pilot', obj.name)
                     if not_in_collection then 'select2-result-not-in-collection' else ''
                 else
                     ''
@@ -2532,7 +2532,7 @@ class Ship
             @builder.backend_status.fadeOut 'slow'
         @pilot_selector.data('select2').results.on 'mousemove-filtered', (e) =>
             select2_data = $(e.target).closest('.select2-result').data 'select2-data'
-            @builder.showTooltip 'Pilot', exportObj.pilotsById[select2_data.id], {ship: @data?.english_name} if select2_data?.id?
+            @builder.showTooltip 'Pilot', exportObj.pilotsById[select2_data.id], {ship: @data?.name} if select2_data?.id?
         @pilot_selector.data('select2').container.on 'mouseover', (e) =>
             @builder.showTooltip 'Ship', this if @data?
         @pilot_selector.data('select2').container.on 'touchmove', (e) =>
@@ -3186,11 +3186,11 @@ class GenericAddon
                 if obj.id == @data?.id
                     # Currently selected card; mark as not in collection if it's neither
                     # on the shelf nor on the table
-                    unless (@ship.builder.collection.checkShelf(@type.toLowerCase(), obj.english_name) or @ship.builder.collection.checkTable(@type.toLowerCase(), obj.english_name))
+                    unless (@ship.builder.collection.checkShelf(@type.toLowerCase(), obj.name) or @ship.builder.collection.checkTable(@type.toLowerCase(), obj.name))
                         not_in_collection = true
                 else
                     # Not currently selected; check shelf only
-                    not_in_collection = not @ship.builder.collection.checkShelf(@type.toLowerCase(), obj.english_name)
+                    not_in_collection = not @ship.builder.collection.checkShelf(@type.toLowerCase(), obj.name)
                 if not_in_collection then 'select2-result-not-in-collection' else ''
                     #and (@ship.builder.collection.checkcollection?) 
             else


### PR DESCRIPTION
Besides lacking all kinds of usefull comments, the code contains quite a bunch of stuff not beeing used at all. This PR aims for a better readability by removing some of it: 
- english_name and english_ship (I guess somebody somewhen started to implement this, but did never complete it? display_names work fine and seem to do their job)
- title specific lists and stuff (are handled like any other upgrade, the special lists are empty and not in use. Just check exportObj.titles in any console)
- modification specific lists and stuff (see title)