### PR TITLE
Fixing issue where upgrade sort order

### DIFF
--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -6,7 +6,9 @@
 exportObj = exports ? this
 
 exportObj.sortHelper = (a, b) ->
-    if a.points == b.points
+    if typeof(a.points) == "string" # handling cases where points value is "*" instead of a number
+        1
+    else if a.points == b.points
         a_name = a.text.replace(/[^a-z0-9]/ig, '')
         b_name = b.text.replace(/[^a-z0-9]/ig, '')
         if a_name == b_name
@@ -1421,7 +1423,7 @@ class exportObj.SquadBuilder
         retval = ({ id: upgrade.id, text: "#{if upgrade.display_name then upgrade.display_name else upgrade.name} (#{upgrade.points})", points: upgrade.points, name: upgrade.name, display_name: upgrade.display_name, disabled: upgrade not in eligible_upgrades } for upgrade in available_upgrades)
         if sorted
             retval = retval.sort exportObj.sortHelper
-        
+
         # Possibly adjust the upgrade
         if this_upgrade_obj?adjustment_func?
             (this_upgrade_obj.adjustment_func(upgrade) for upgrade in retval)


### PR DESCRIPTION
Fixing issue where upgrades with points value of * were messing up the sort order.  For example Expert Handling with points of "*" was pushing Elusive down to the bottom.

Fixed example:
<img width="670" alt="screen shot 2018-11-02 at 7 54 54 pm" src="https://user-images.githubusercontent.com/58073/47945667-e5d4d400-ded9-11e8-8c24-db7226d5d042.png">

This also fixes the modifications order:
<img width="298" alt="screen shot 2018-11-02 at 8 03 54 pm" src="https://user-images.githubusercontent.com/58073/47945752-9642d800-deda-11e8-9851-6e816ece2ad2.png">
