### PR TITLE
Fixes a possible null deref when checking collections

### DIFF
--- a/coffeescripts/browser.coffee
+++ b/coffeescripts/browser.coffee
@@ -610,11 +610,11 @@ class exportObj.CardBrowser
         owned_copies = 0
         switch card.orig_type
             when 'Pilot'
-                owned_copies = exportObj.builders[0].collection.counts.pilot[card.name] ? 0 
+                owned_copies = exportObj.builders[0].collection.counts.pilot?[card.name] ? 0
             when 'Ship'
-                owned_copies = exportObj.builders[0].collection.counts.ship[card.name] ? 0
+                owned_copies = exportObj.builders[0].collection.counts.ship?[card.name] ? 0
             else # type is e.g. astromech
-                owned_copies = exportObj.builders[0].collection.counts.upgrade[card.name] ? 0
+                owned_copies = exportObj.builders[0].collection.counts.upgrade?[card.name] ? 0
         owned_copies
 
 


### PR DESCRIPTION
No defaults are set for card type containers in "collections.counts", so existence must be checked
Occurs when a logged-in user has not set a collection

Effect of the issue is a blank squad UI, and the squad URL is reset.  

Other workaround: User can set a nonzero value in their collection somewhere

Example:
https://raithos.github.io/?f=Galactic%20Empire&d=v5!c=200!179:124,-1,-1:;191:111,136,-1,-1,-1,-1,71,-1:;199:123,112,26,-1:&sn=Soontir%20%2B%20Redline%20%2B%20Whisper&obs=

![image](https://user-images.githubusercontent.com/784689/49763740-5f52a580-fc82-11e8-9f04-7c43b1481bbb.png)
