### PR TITLE
Made Saw crew legal for hyperspace

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -7094,6 +7094,7 @@ exportObj.basicCardData = ->
            points: 8
            unique: true
            faction: "Rebel Alliance"
+           isHyperspace: true
        }
        {
            name: "Seasoned Navigator"


### PR DESCRIPTION
Added 'isHyperspace: true' flag to the Saw crew card. This is for issue #235.