### PR TITLE
Add Quickbuild Mode

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -9116,6 +9116,18 @@ exportObj.basicCardData = ->
                 "Proton Rockets"
             ]
         }
+        {
+            id: 47
+            faction: "Galactic Empire"
+            pilot: "Tomax Bren"
+            ship: "TIE/sa Bomber"
+            threat: 2
+            upgrades: [
+                "Crack Shot"
+		        "Proton Torpedoes"
+		        "Proton Bombs"
+            ]
+        }
     ]
 
 

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -9133,7 +9133,7 @@ exportObj.basicCardData = ->
             faction: "Galactic Empire"
             pilot: "Deathfire"
             ship: "TIE Bomber"
-            threat: 4
+            threat: 2
             upgrades: [
                 "Cluster Missiles"
                 "Skilled Bombardier"

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -9132,7 +9132,7 @@ exportObj.basicCardData = ->
             id: 48
             faction: "Galactic Empire"
             pilot: "Deathfire"
-            ship: "TIE/sa Bomber"
+            ship: "TIE Bomber"
             threat: 4
             upgrades: [
                 "Cluster Missiles"

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -8774,6 +8774,348 @@ exportObj.basicCardData = ->
             threat: 1
             skip: true
         }
+        {
+            id: 18
+            faction: "Galactic Empire"
+            pilot: "Darth Vader"
+            ship: "TIE Advanced"
+            threat: 4
+            upgrades: [
+                "Supernatural Reflexes"
+                "Fire-Control System"
+                "Afterburners"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 19
+            faction: "Galactic Empire"
+            pilot: "Maarek Stele"
+            ship: "TIE Advanced"
+            threat: 3
+            upgrades: [
+                "Ruthless"
+                "Fire-Control System"
+                "Cluster Missiles"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 20
+            faction: "Galactic Empire"
+            pilot: "Storm Squadron Ace"
+            ship: "TIE Advanced"
+            threat: 2
+            upgrades: [
+                "Fire-Control System"
+            ]
+        }
+        {
+            id: 21
+            faction: "Galactic Empire"
+            pilot: "Ved Foslo"
+            ship: "TIE Advanced"
+            threat: 3
+            upgrades: [
+                "Outmaneuver"
+                "Fire-Control System"
+                "Cluster Missiles"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 22
+            faction: "Galactic Empire"
+            pilot: "Zertik Strom"
+            ship: "TIE Advanced"
+            threat: 3
+            upgrades: [
+                "Squad Leader"
+                "Fire-Control System"
+                "Cluster Missiles"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 23
+            faction: "Galactic Empire"
+            pilot: "Tempest Squadron Pilot"
+            ship: "TIE Advanced"
+            threat: 2
+            upgrades: [
+                "Cluster Missiles"
+            ]
+        }
+        {
+            id: 24
+            faction: "Galactic Empire"
+            pilot: "Colonel Jendon"
+            ship: "Lambda-Class Shuttle"
+            threat: 3
+            upgrades: [
+                "Collision Detector"
+                "Ion Cannon"
+                "Darth Vader"
+                "Freelance Slicer"
+                "ST-321"
+            ]
+        }
+        {
+            id: 25
+            faction: "Galactic Empire"
+            pilot: "Captain Kagi"
+            ship: "Lambda-Class Shuttle"
+            threat: 3
+            upgrades: [
+                "Collision Detector"
+                "Tractor Beam"
+                "Emperor Palpatine"
+                "Shield Upgrade"
+                "Static Discharge Vanes"
+            ]
+        }
+        {
+            id: 26
+            faction: "Galactic Empire"
+            pilot: "Lieutenant Sai"
+            ship: "Lambda-Class Shuttle"
+            threat: 3
+            upgrades: [
+                "Ciena Ree"
+                'GNK "Gonk" Droid'
+                "Advanced Sensors"
+                "Jamming Beam"
+            ]
+        }
+        {
+            id: 27
+            faction: "Galactic Empire"
+            pilot: "Omicron Group Pilot"
+            ship: "Lambda-Class Shuttle"
+            threat: 2
+            upgrades: [
+                "Admiral Sloane"
+                "Jamming Beam"
+            ]
+        }
+        {
+            id: 28
+            faction: "Galactic Empire"
+            pilot: "Lieutenant Kestal"
+            ship: "TIE Aggressor"
+            threat: 2
+            upgrades: [
+                "Elusive"
+                "Barrage Rockets"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 29
+            faction: "Galactic Empire"
+            pilot: "Onyx Squadron Scout"
+            ship: "TIE Aggressor"
+            threat: 2
+            upgrades: [
+                "Outmaneuver"
+                "Dorsal Turret"
+                "Proton Rockets"
+            ]
+        }
+        {
+            id: 30
+            faction: "Galactic Empire"
+            pilot: '"Double Edge"'
+            ship: "TIE Aggressor"
+            threat: 2
+            upgrades: [
+                "Ion Cannon Turret"
+                "Concussion Missiles"
+                "Hotshot Gunner"
+            ]
+        }
+        {
+            id: 31
+            faction: "Galactic Empire"
+            pilot: "Sienar Specialist"
+            ship: "TIE Aggressor"
+            threat: 2
+            upgrades: [
+                "Ion Cannon Turret"
+                "Homing Missiles"
+                "Veteran Turret Gunner"
+                "Hull Upgrade"
+            ]
+        }
+        {
+            id: 32
+            faction: "Galactic Empire"
+            pilot: '"Whisper"'
+            ship: "TIE Phantom"
+            threat: 3
+            upgrades: [
+                "Juke"
+                "Advanced Sensors"
+                "Agent Kallus"
+                "Stealth Device"
+            ]
+        }
+        {
+            id: 33
+            faction: "Galactic Empire"
+            pilot: "Sigma Squadron Ace"
+            ship: "TIE Phantom"
+            threat: 3
+            upgrades: [
+                "Predator"
+                "Advanced Sensors"
+                "Grand Inquisitor"
+            ]
+        }
+        {
+            id: 34
+            faction: "Galactic Empire"
+            pilot: '"Echo"'
+            ship: "TIE Phantom"
+            threat: 3
+            upgrades: [
+                "Lone Wolf"
+                "Collision Detector"
+                "Perceptive Copilot"
+                "Stealth Device"
+            ]
+        }
+        {
+            id: 35
+            faction: "Galactic Empire"
+            pilot: "Imdaar Test Pilot"
+            ship: "TIE Phantom"
+            threat: 2
+            upgrades: [
+                "Moff Jerjerrod"
+            ]
+        }
+        {
+            id: 36
+            faction: "Galactic Empire"
+            pilot: '"Duchess"'
+            ship: "TIE Striker"
+            threat: 2
+            upgrades: [
+                "Trick Shot"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 37
+            faction: "Galactic Empire"
+            pilot: "Black Squadron Scout"
+            ship: "TIE Striker"
+            threat: 2
+            upgrades: [
+                "Skilled Bombardier"
+                "Proximity Mines"
+                "Hull Upgrade"
+            ]
+        }
+        {
+            id: 38
+            faction: "Galactic Empire"
+            pilot: '"Countdown"'
+            ship: "TIE Striker"
+            threat: 2
+            upgrades: [
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 39
+            faction: "Galactic Empire"
+            pilot: "Planetary Sentinel"
+            suffix: " x2"
+            ship: "TIE Striker"
+            threat: 3
+            upgrades: [
+                "Conner Nets"
+            ]
+        }
+        {
+            id: 40
+            faction: "Galactic Empire"
+            pilot: '"Pure Sabacc"'
+            ship: "TIE Striker"
+            threat: 2
+            upgrades: [
+                "Stealth Device"
+            ]
+        }
+        {
+            id: 41
+            faction: "Galactic Empire"
+            pilot: "Black Squadron Scout"
+            ship: "TIE Striker"
+            threat: 2
+            upgrades: [
+                "Skilled Bombardier"
+                "Proximity Mines"
+                "Hull Upgrade"
+            ]
+            skip: true
+        }
+        {
+            id: 42
+            faction: "Galactic Empire"
+            pilot: "Countess Ryad"
+            ship: "TIE Defender"
+            threat: 4
+            upgrades: [
+                "Outmaneuver"
+                "Afterburners"
+            ]
+        }
+        {
+            id: 43
+            faction: "Galactic Empire"
+            pilot: "Onyx Squadron Ace"
+            ship: "TIE Defender"
+            threat: 3
+        }
+        {
+            id: 44
+            faction: "Galactic Empire"
+            pilot: "Rexler Brath"
+            ship: "TIE Defender"
+            threat: 4
+            upgrades: [
+                "Juke"
+                "Collision Detector"
+                "Cluster Missiles"
+            ]
+        }
+        {
+            id: 45
+            faction: "Galactic Empire"
+            pilot: "Colonel Vessery"
+            ship: "TIE Defender"
+            threat: 4
+            upgrades: [
+                "Juke"
+                "Fire Control System"
+                "Cluster Missiles"
+            ]
+        }
+        {
+            id: 46
+            faction: "Galactic Empire"
+            pilot: "Onyx Squadron Ace"
+            ship: "TIE Defender"
+            threat: 4
+            upgrades: [
+                "Elusive"
+                "Advanced Sensors"
+                "Proton Rockets"
+            ]
+        }
     ]
 
 

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -9124,8 +9124,8 @@ exportObj.basicCardData = ->
             threat: 2
             upgrades: [
                 "Crack Shot"
-		        "Proton Torpedoes"
-		        "Proton Bombs"
+		"Proton Torpedoes"
+		"Proton Bombs"
             ]
         }
     ]

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -9128,6 +9128,20 @@ exportObj.basicCardData = ->
                 "Proton Bombs"
             ]
         }
+        {
+            id: 48
+            faction: "Galactic Empire"
+            pilot: "Deathfire"
+            ship: "TIE/sa Bomber"
+            threat: 4
+            upgrades: [
+                "Cluster Missiles"
+                "Skilled Bombardier"
+                "Seismic Charges"
+                "Proximity Mines"
+                "Electronic Baffle"
+            ]
+        }
     ]
 
 

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -8617,6 +8617,163 @@ exportObj.basicCardData = ->
             ship: "TIE Fighter"
             threat: 1
         }
+        {
+            id: 3
+            faction: "Galactic Empire"
+            pilot: "Iden Versio"
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Outmaneuver"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 4
+            faction: "Galactic Empire"
+            pilot: '"Night Beast"'
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Predator"
+                "Hull Upgrade"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 5
+            faction: "Galactic Empire"
+            pilot: "Obsidian Squadron Pilot"
+            ship: "TIE Fighter"
+            threat: 1
+        }
+        {
+            id: 6
+            faction: "Galactic Empire"
+            pilot: '"Scourge" Skutu'
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Predator"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 7
+            faction: "Galactic Empire"
+            pilot: '"Wampa"'
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Crack Shot"
+                "Hull Upgrade"
+                "Stealth Device"
+            ]
+        }
+        {
+            id: 8
+            faction: "Galactic Empire"
+            pilot: "Black Squadron Ace"
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Crack Shot"
+                "Afterburners"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 9
+            faction: "Galactic Empire"
+            pilot: "Gideon Hask"
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Crack Shot"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 10
+            faction: "Galactic Empire"
+            pilot: "Del Meeko"
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Juke"
+                "Stealth Device"
+            ]
+        }
+        {
+            id: 11
+            faction: "Galactic Empire"
+            pilot: "Obsidian Squadron Pilot"
+            ship: "TIE Fighter"
+            threat: 1
+            skip: true
+        }
+        {
+            id: 12
+            faction: "Galactic Empire"
+            pilot: '"Howlrunner"'
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Juke"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 13
+            faction: "Galactic Empire"
+            pilot: "Seyn Marana"
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Marksmanship"
+                "Afterburners"
+            ]
+        }
+        {
+            id: 14
+            faction: "Galactic Empire"
+            pilot: "Black Squadron Ace"
+            suffix: " (x2)"
+            ship: "TIE Fighter"
+            threat: 3
+            upgrades: [
+                "Juke"
+                "Stealth Device"
+            ]
+        }
+        {
+            id: 15
+            faction: "Galactic Empire"
+            pilot: "Obsidian Squadron Pilot"
+            suffix: " (x2)"
+            ship: "TIE Fighter"
+            threat: 3
+            upgrades: [
+                "Outmaneuver"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 16
+            faction: "Galactic Empire"
+            pilot: "Academy Pilot"
+            suffix: " (x2)"
+            ship: "TIE Fighter"
+            threat: 2
+        }
+        {
+            id: 17
+            faction: "Galactic Empire"
+            pilot: "Academy Pilot"
+            ship: "TIE Fighter"
+            threat: 1
+            skip: true
+        }
     ]
 
 

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -9100,7 +9100,7 @@ exportObj.basicCardData = ->
             threat: 4
             upgrades: [
                 "Juke"
-                "Fire Control System"
+                "Fire-Control System"
                 "Cluster Missiles"
             ]
         }
@@ -9120,12 +9120,12 @@ exportObj.basicCardData = ->
             id: 47
             faction: "Galactic Empire"
             pilot: "Tomax Bren"
-            ship: "TIE/sa Bomber"
+            ship: "TIE Bomber"
             threat: 2
             upgrades: [
                 "Crack Shot"
-		"Proton Torpedoes"
-		"Proton Bombs"
+                "Proton Torpedoes"
+                "Proton Bombs"
             ]
         }
     ]

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -9131,7 +9131,7 @@ exportObj.basicCardData = ->
         {
             id: 48
             faction: "Galactic Empire"
-            pilot: "Deathfire"
+            pilot: '"Deathfire"'
             ship: "TIE Bomber"
             threat: 2
             upgrades: [

--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -8586,6 +8586,39 @@ exportObj.basicCardData = ->
         }
     ]
 
+    quickbuildsById: [
+        {
+            id: 0
+            faction: "Galactic Empire"
+            pilot: "Valen Rudor"
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Elusive"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 1
+            faction: "Galactic Empire"
+            pilot: "Black Squadron Ace"
+            ship: "TIE Fighter"
+            threat: 2
+            upgrades: [
+                "Outmaneuver"
+                "Afterburners"
+                "Shield Upgrade"
+            ]
+        }
+        {
+            id: 2
+            faction: "Galactic Empire"
+            pilot: "Academy Pilot"
+            ship: "TIE Fighter"
+            threat: 1
+        }
+    ]
+
 
 
 exportObj.setupCommonCardData = (basic_cards) ->
@@ -8599,6 +8632,10 @@ exportObj.setupCommonCardData = (basic_cards) ->
     for condition_data, i in basic_cards.conditionsById
         if condition_data.id != i
             throw new Error("ID mismatch: condition at index #{i} has ID #{condition_data.id}")
+    for quickbuild_data, i in basic_cards.quickbuildsById
+        if quickbuild_data.id != i
+            throw new Error("ID mismatch: quickbuild  at index #{i} has ID #{quickbuild_data.id}")
+
 
     exportObj.pilots = {}
     # Assuming a given pilot is unique by name...
@@ -8623,6 +8660,19 @@ exportObj.setupCommonCardData = (basic_cards) ->
             condition_data.sources = []
             condition_data.canonical_name = condition_data.name.canonicalize() unless condition_data.canonical_name?
             exportObj.conditions[condition_data.name] = condition_data
+
+    # there is no exportObj.quickbuilds generated from basic_cards.quickbuildsById, as reference by pilot name might be ambigous (e.g. there are multiple Black Sq. Aces having different upgrades)
+
+    exportObj.quickbuildsById = {}
+    quickbuild_count = 0
+    for quickbuild_data in basic_cards.quickbuildsById
+        unless quickbuild_data.skip? 
+            quickbuild_count += 1
+            # Sometimes there is something to be appended to the pilot name for displaying, e.g. (x2) for two TIEs at the cost of 3 threat points. If nothing specified set as empty string. 
+            quickbuild_data.suffix = "" unless quickbuild_data.suffix? 
+            exportObj.quickbuildsById[quickbuild_data.id] = quickbuild_data
+    if Object.keys(exportObj.quickbuildsById).length != quickbuild_count
+        throw new Error("At least one quickbuild shares an ID with another")
 
     for ship_name, ship_data of basic_cards.ships
         ship_data.canonical_name ?= ship_data.name.canonicalize()

--- a/coffeescripts/cards-en.coffee
+++ b/coffeescripts/cards-en.coffee
@@ -313,7 +313,7 @@ exportObj.cardLoaders.English = () ->
            text: """<i class = flavor_text>Due to its heavy weapons array and resilient shielding, the B-wing has solidified itself as the Rebel Alliance’s most innovative assault fighter.</i>"""
         "Blue Squadron Recruit":
            display_name: """Blue Squadron Recruit"""
-           text: """<i class = flavor_text>Young beings across the galaxy have grown up on tales of heroism in the Galactic Civil War, and many learned to fly in the same cockpits from which their parents fought the Empire.</i>%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red <rotate> action."""
+           text: """<i class = flavor_text>Young beings across the galaxy have grown up on tales of heroism in the Galactic Civil War, and many learned to fly in the same cockpits from which their parents fought the Empire.</i>%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red %ROTATEARC% action."""
         "Blue Squadron Rookie":
            display_name: """Blue Squadron Rookie"""
            text: """<i class = flavor_text>The Incom-FreiTek T-70 X-Wing was designed to improve upon the tactical flexibility of the venerable T-65. The starfighter’s advanced droid socket is compatible with a wide array of astromechs, and its modular weapons pods allow ground crews to tailor its payload for specific missions.</i>%LINEBREAK%<strong>Weapon Hardpoint:</strong> You can equip 1&nbsp;%CANNON%, %TORPEDO%, or %MISSILE% upgrade."""
@@ -526,13 +526,13 @@ exportObj.cardLoaders.English = () ->
            text: """While you defend, if you are behind the attacker, roll 1 additional defense die.%LINEBREAK%While you perform an attack, if you are behind the defender, roll 1 additional attack die."""
         "Green Squadron Expert":
            display_name: """Green Squadron Expert"""
-           text: """<i class = flavor_text>Years of field-expedient modifications were standardized in the RZ-2 design, but daring pilots see the ship’s improved reliability as a challenge to further push the limits of its performance.</i>%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red <rotate> action."""
+           text: """<i class = flavor_text>Years of field-expedient modifications were standardized in the RZ-2 design, but daring pilots see the ship’s improved reliability as a challenge to further push the limits of its performance.</i>%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red %ROTATEARC% action."""
         "Green Squadron Pilot":
            display_name: """Green Squadron Pilot"""
            text: """<i class = flavor_text>Due to its sensitive controls and high maneuverability, only the most talented pilots belong in an A-wing cockpit.</i>%LINEBREAK%<strong>Vectored Thrusters:</strong> After you perform an action, you may perform a red %BOOST% action."""
         "Greer Sonnel":
            display_name: """Greer Sonnel"""
-           text: """After you fully execute a maneuver, you may rotate your %SINGLETURRETARC%.%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red <rotate> action."""
+           text: """After you fully execute a maneuver, you may rotate your %SINGLETURRETARC%.%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red %ROTATEARC% action."""
         "Guri":
            display_name: """Guri"""
            text: """At the start of the Engagement Phase, if there is at least 1 enemy ship at range 0-1, you may gain 1 focus token.%LINEBREAK% <strong>Microthrusters:</strong> While you perform a barrel roll, you <b>must</b> use the %BANKLEFT% or %BANKRIGHT% template instead of the %STRAIGHT% template."""
@@ -716,7 +716,7 @@ exportObj.cardLoaders.English = () ->
            text: """After you become the defender (before dice are rolled), you may recover 1&nbsp;%FORCE%."""
         "L'ulo L'ampar":
            display_name: """L’ulo L’ampar"""
-           text: """While you defend or perform a primary attack, if you are stressed, you <b>must</b> roll 1 fewer defense die or 1 additional attack die.%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red <rotate> action."""
+           text: """While you defend or perform a primary attack, if you are stressed, you <b>must</b> roll 1 fewer defense die or 1 additional attack die.%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red %ROTATEARC% action."""
         "Maarek Stele":
            display_name: """Maarek Stele"""
            text: """While you perform an attack, if the defender would be dealt a faceup damage card, instead draw 3 damage cards, choose 1, and discard the rest.%LINEBREAK%<strong>Advanced Targeting Computer:</strong> While you perform a primary attack against a defender you have locked, roll 1 additional attack die and change 1&nbsp;%HIT% result to a %CRIT% result. """
@@ -929,7 +929,7 @@ exportObj.cardLoaders.English = () ->
            text: """<i class = flavor_text>The AF4 series is the latest in a long line of Headhunter designs. Cheap and relatively durable, it is a favorite among independent outfits like the Rebellion.</i>"""
         "Tallissan Lintra":
            display_name: """Tallissan Lintra"""
-           text: """While an enemy ship in your %BULLSEYEARC% performs an attack, you may spend 1&nbsp;%CHARGE%.  If you do, the defender rolls 1 additional die.%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red <rotate> action."""
+           text: """While an enemy ship in your %BULLSEYEARC% performs an attack, you may spend 1&nbsp;%CHARGE%.  If you do, the defender rolls 1 additional die.%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red %ROTATEARC% action."""
         "Talonbane Cobra":
            display_name: """Talonbane Cobra"""
            text: """While you defend at attack range 3 or perform an attack at attack range 1, roll 1 additional die."""
@@ -995,7 +995,7 @@ exportObj.cardLoaders.English = () ->
            text: """While you perform a primary attack, if you are damaged, you may roll 1 additional attack die."""
         "Zari Bangel":
            display_name: """Zari Bangel"""
-           text: """You do not skip your Perform Action step after you partially execute a maneuver.%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red <rotate> action."""
+           text: """You do not skip your Perform Action step after you partially execute a maneuver.%LINEBREAK%<strong>Refined Gyrostabilizers:</strong> You can rotate your %SINGLETURRETARC% indicator only to your %FRONTARC% or %REARARC%. After you perform an action, you may perform a red %BOOST% or red %ROTATEARC% action."""
         "Zealous Recruit":
            display_name: """Zealous Recruit"""
            text: """<i class = flavor_text>Mandalorian Fang fighter pilots must master the Concordia Faceoff maneuver, leveraging their ships’ narrow attack profile to execute deadly head-on charges.</i> %LINEBREAK% <strong>Concordia Faceoff:</strong> While you defend, if the attack range is 1 and you are in the attacker’s %FRONTARC%, change 1 result to an %EVADE% result."""
@@ -1622,7 +1622,7 @@ exportObj.cardLoaders.English = () ->
            text: """<i>Resistance only</i>%LINEBREAK%While you defend or perform an attack, if the enemy ship is in your %SINGLETURRETARC%, you may spend 1&nbsp;%FORCE% to change 1 of your blank results to a %EVADE% or %HIT% result."""
         "Rey's Millennium Falcon":
            display_name: """Rey’s Millennium Falcon"""
-           text: """<i>Resistance only</i>%LINEBREAK%If you have 2 or fewer stress tokens, you can execute red Segnor’s Loop [%SLOOPLEFT% or %SLOOPRIGHT%] maneuvers and perform %BOOST% and&nbsp;<rotate> actions even while stressed."""
+           text: """<i>Resistance only</i>%LINEBREAK%If you have 2 or fewer stress tokens, you can execute red Segnor’s Loop [%SLOOPLEFT% or %SLOOPRIGHT%] maneuvers and perform %BOOST% and&nbsp;%ROTATEARC% actions even while stressed."""
         "Rigged Cargo Chute":
            display_name: """Rigged Cargo Chute"""
            text: """<i>large ship or medium ship only</i>%LINEBREAK%<strong>Action:</strong> Spend 1&nbsp;%CHARGE%. Drop 1 loose cargo using the [1&nbsp;%STRAIGHT%] template."""

--- a/coffeescripts/cards-it.coffee
+++ b/coffeescripts/cards-it.coffee
@@ -91,7 +91,7 @@ exportObj.cardLoaders.Italiano = () ->
            text: """<i class = flavor_text>Grazie al suo arsenale di armi pesanti e alla sua resistente schermatura, l’Ala-B si è consolidato come il caccia d’assalto più innovativo dell’Alleanza Ribelle.</i>"""
         "Blue Squadron Recruit":
            display_name: """Recluta della Squadriglia Blu"""
-           text: """<i class = flavor_text>I giovani di tutta la galassia sono cresciuti ascoltando le storie degli atti eroici della Guerra Civile Galattica e molti di loro hanno imparato a volare negli stessi abitacoli in cui i loro genitori combatterono contro l’Impero.</i>%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o <rotate> rossa."""
+           text: """<i class = flavor_text>I giovani di tutta la galassia sono cresciuti ascoltando le storie degli atti eroici della Guerra Civile Galattica e molti di loro hanno imparato a volare negli stessi abitacoli in cui i loro genitori combatterono contro l’Impero.</i>%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o %ROTATEARC% rossa."""
         "Blue Squadron Rookie":
            display_name: """Matricola della Squadriglia Blu"""
            text: """<i class = flavor_text>L’Ala-X T-70 della Incom-FreiTek fu progettato per migliorare la flessibilità tattica del vetusto T-65. L’innesto avanzato per droidi di cui è dotato lo rende compatibile con una vasta gamma di droidi astromeccanici e i suoi blocchi di armi modulari permettono al pilota di adattare l’arsenale ai bisogni di ogni specifica missione.</i>%LINEBREAK%<strong>Innesto Armato:</strong> Puoi dotarti di 1 miglioria&nbsp;%CANNON%, %TORPEDO% o %MISSILE%."""
@@ -304,13 +304,13 @@ exportObj.cardLoaders.Italiano = () ->
            text: """Mentre difendi, se sei dietro l’attaccante, tira 1 dado di difesa aggiuntivo.%LINEBREAK%Mentre effettui un attacco, se sei dietro il difensore, tira 1 dado di attacco aggiuntivo."""
         "Green Squadron Expert":
            display_name: """Esperto della Squadriglia Verde"""
-           text: """<i class = flavor_text>Il frutto di anni di modifiche e collaudi sul campo si è concretizzato nel modello RZ-2, ma i piloti più temerari vedono nella maggiore affidabilità della nave una sfida a spingere le sue prestazioni verso nuovi limiti.</i>%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o <rotate> rossa."""
+           text: """<i class = flavor_text>Il frutto di anni di modifiche e collaudi sul campo si è concretizzato nel modello RZ-2, ma i piloti più temerari vedono nella maggiore affidabilità della nave una sfida a spingere le sue prestazioni verso nuovi limiti.</i>%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o %ROTATEARC% rossa."""
         "Green Squadron Pilot":
            display_name: """Pilota della Squadriglia Verde"""
            text: """<i class = flavor_text>Grazie ai suoi comandi sensibili e alla sua alta manovrabilità, l’abitacolo di un Ala-A era un luogo riservato soltanto ai piloti più dotati.</i>%LINEBREAK%<strong>Propulsori Vettoriali:</strong> Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% rossa."""
         "Greer Sonnel":
            display_name: """Greer Sonnel"""
-           text: """Dopo che hai eseguito completamente una manovra, puoi ruotare il tuo segnalatore %SINGLETURRETARC%.%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o <rotate> rossa."""
+           text: """Dopo che hai eseguito completamente una manovra, puoi ruotare il tuo segnalatore %SINGLETURRETARC%.%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o %ROTATEARC% rossa."""
         "Guri":
            display_name: """Guri"""
            text: """All’inizio della Fase di Ingaggio, se ci sono navi nemiche a gittata 0-1, puoi ottenere 1 segnalino concentrazione.%LINEBREAK%<strong>Micropropulsori:</strong> Mentre effettui un avvitamento, devi usare il modello %BANKLEFT% o %BANKRIGHT% invece del modello %STRAIGHT%."""
@@ -493,7 +493,7 @@ exportObj.cardLoaders.Italiano = () ->
            text: """Dopo che sei diventato il difensore (prima che i dadi siano tirati), puoi recuperare 1&nbsp;%FORCE%."""
         "L'ulo L'ampar":
            display_name: """L’ulo L’ampar"""
-           text: """Mentre difendi o effettui un attacco primario, se sei in tensione, <b>devi </b>tirare 1 dado di difesa in meno o 1 dado di attacco aggiuntivo.%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o <rotate> rossa."""
+           text: """Mentre difendi o effettui un attacco primario, se sei in tensione, <b>devi </b>tirare 1 dado di difesa in meno o 1 dado di attacco aggiuntivo.%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o %ROTATEARC% rossa."""
         "Maarek Stele":
            display_name: """Maarek Stele"""
            text: """Mentre effettui un attacco, se al difensore sta per essere inflitta una carta danno a faccia in su, pesca invece 3 carte danno, scegline 1 e scarta le altre.%LINEBREAK%<strong>Computer d’Attacco Avanzato:</strong> Mentre effettui un attacco primario contro un difensore che hai acquisito come bersaglio, tira 1 dado di attacco aggiuntivo e cambia 1 risultato %HIT% in 1 risultato %CRIT%."""
@@ -706,7 +706,7 @@ exportObj.cardLoaders.Italiano = () ->
            text: """<i class = flavor_text>La serie AF4 è l’ultima di una lunga linea di modelli Headhunter. Questo caccia economico e relativamente resistente è uno dei veicoli preferiti dalle organizzazioni indipendenti come la Ribellione.</i>"""
         "Tallissan Lintra":
            display_name: """Tallissan Lintra"""
-           text: """Mentre una nave nemica nel tuo %BULLSEYEARC% effettua un attacco, puoi spendere 1 %CHARGE%. Se lo fai, il difensore tira 1 dado aggiuntivo.%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o <rotate> rossa."""
+           text: """Mentre una nave nemica nel tuo %BULLSEYEARC% effettua un attacco, puoi spendere 1 %CHARGE%. Se lo fai, il difensore tira 1 dado aggiuntivo.%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o %ROTATEARC% rossa."""
         "Talonbane Cobra":
            display_name: """Talonbane Cobra"""
            text: """Mentre difendi a gittata di attacco 3 o effettui un attacco a gittata di attacco 1, tira 1 dado aggiuntivo."""
@@ -772,7 +772,7 @@ exportObj.cardLoaders.Italiano = () ->
            text: """Mentre effettui un attacco primario, se sei danneggiato, puoi tirare 1 dado di attacco aggiuntivo."""
         "Zari Bangel":
            display_name: """Zari Bangel"""
-           text: """Dopo che hai eseguito parzialmente una manovra, non saltare il tuo passo “Effettuare l’Azione”.%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o <rotate> rossa."""
+           text: """Dopo che hai eseguito parzialmente una manovra, non saltare il tuo passo “Effettuare l’Azione”.%LINEBREAK%<strong>Girostabilizzatori Affinati:</strong> Puoi ruotare il tuo segnalatore %SINGLETURRETARC% solo sui tuoi %FRONTARC% o %REARARC%. Dopo che hai effettuato un’azione, puoi effettuare 1 azione %BOOST% o %ROTATEARC% rossa."""
         "Zealous Recruit":
            display_name: """Recluta Zelante"""
            text: """<i class = flavor_text>I piloti dei Caccia Fang mandaloriani devono imparare a padroneggiare la Carica Frontale di Concordia, una manovra che sfrutta l’esile profilo di attacco delle loro navi per lanciarsi in una micidiale carica frontale.</i>%LINEBREAK%<strong>Carica Frontale di Concordia:</strong> Mentre difendi, se la gittata di attacco è 1 e sei nel %FRONTARC% dell’attaccante, cambia 1 risultato in 1 risultato %EVADE%."""
@@ -1364,7 +1364,7 @@ exportObj.cardLoaders.Italiano = () ->
            text: """<i>CHANGE MECHANGE ME</i>%LINEBREAK%Mentre difendi o effettui un attacco, se la nave nemica è nel tuo %SINGLETURRETARC%, puoi spendere 1 %FORCE% per cambiare 1 tuo risultato vuoto in 1 risultato %EVADE% o %HIT%."""
         "Rey's Millennium Falcon":
            display_name: """Millennium Falcon di Rey"""
-           text: """<i>CHANGE MECHANGE ME</i>%LINEBREAK%Se possiedi 2 o meno segnalini tensione, puoi eseguire le manovre loop di Segnor [%SLOOPLEFT% o %SLOOPRIGHT%] rosse ed effettuare le azioni %BOOST% e&nbsp;<rotate> anche mentre sei in tensione."""
+           text: """<i>CHANGE MECHANGE ME</i>%LINEBREAK%Se possiedi 2 o meno segnalini tensione, puoi eseguire le manovre loop di Segnor [%SLOOPLEFT% o %SLOOPRIGHT%] rosse ed effettuare le azioni %BOOST% e&nbsp;%ROTATEARC% anche mentre sei in tensione."""
         "Rigged Cargo Chute":
            display_name: """Rampa di Carico Attrezzata"""
            text: """<i>CHANGE MECHANGE ME CHANGE ME CHANGE ME</i>%LINEBREAK%<strong>Azione:</strong> Spendi 1 %CHARGE%. Sgancia 1 carico sparso usando il modello [1&nbsp;%STRAIGHT%]."""

--- a/coffeescripts/manifest.coffee
+++ b/coffeescripts/manifest.coffee
@@ -4974,16 +4974,9 @@ class exportObj.Collection
             </div>
         """
 
-                
-    fixName: (name) ->
-        # Special case handling for Heavy Scyk :(
-        if name.indexOf('"Heavy Scyk" Interceptor') == 0
-            '"Heavy Scyk" Interceptor'
-        else
-            name
 
     check: (where, type, name) ->
-        (((where[type] ? {})[@fixName name] ? []).length ? 0) != 0
+        (((where[type] ? {})[name] ? []).length ? 0) != 0
 
     checkShelf: (type, name) ->
         @check @shelf, type, name
@@ -4992,7 +4985,6 @@ class exportObj.Collection
         @check @table, type, name
 
     use: (type, name) ->
-        name = @fixName name
         try
             card = @shelf[type][name].pop()
         catch e
@@ -5005,7 +4997,6 @@ class exportObj.Collection
             false
 
     release: (type, name) ->
-        name = @fixName name
         try
             card = @table[type][name].pop()
         catch e

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -3090,7 +3090,7 @@ class Ship
                 <div class="pilot-header-text">#{if @pilot.display_name then @pilot.display_name else @pilot.name} <i class="xwing-miniatures-ship xwing-miniatures-ship-#{@data.xws}"></i><span class="fancy-ship-type"> #{if @data.display_name then @data.display_name else @data.name}</span></div>
                 <div class="mask">
                     <div class="outer-circle">
-                        <div class="inner-circle pilot-points">#{@pilot.points}</div>
+                        <div class="inner-circle pilot-points">#{if @builder.isQuickbuild then exportObj.quickbuildsById[@quickbuildId].threat else @pilot.points}</div>
                     </div>
                 </div>
             </div>
@@ -3153,8 +3153,6 @@ class Ship
         
         Threshold = Math.ceil (effective_stats['hull'] + effective_stats['shields']) / 2
         
-        
-        # if @getPoints() != @pilot.points
         html += $.trim """
             <div class="ship-points-total">
                 <strong>Ship Total: #{@getPoints()}, Half Points: #{HalfPoints}, Threshold: #{Threshold}</strong> 
@@ -3167,7 +3165,7 @@ class Ship
         table_html = $.trim """
             <tr class="simple-pilot">
                 <td class="name">#{if @pilot.display_name then @pilot.display_name else @pilot.name} &mdash; #{if @data.display_name then @data.display_name else @data.name}</td>
-                <td class="points">#{@pilot.points}</td>
+                <td class="points">#{if @builder.isQuickbuild then exportObj.quickbuildsById[@quickbuildId].threat else @pilot.points}</td>
             </tr>
         """
 
@@ -3189,7 +3187,7 @@ class Ship
         table_html
 
     toRedditText: ->
-        reddit = """**#{@pilot.name} (#{@pilot.points})**    \n"""
+        reddit = """**#{@pilot.name} (#{if @builder.isQuickbuild then exportObj.quickbuildsById[@quickbuildId].threat else @pilot.points})**    \n"""
         slotted_upgrades = (upgrade for upgrade in @upgrades when upgrade.data?)
         if slotted_upgrades.length > 0
             reddit +="    \n"
@@ -3214,7 +3212,7 @@ class Ship
         tts
 
     toBBCode: ->
-        bbcode = """[b]#{if @pilot.display_name then @pilot.display_name else @pilot.name} (#{@pilot.points})[/b]"""
+        bbcode = """[b]#{if @pilot.display_name then @pilot.display_name else @pilot.name} (#{if @builder.isQuickbuild then exportObj.quickbuildsById[@quickbuildId].threat else @pilot.points})[/b]"""
 
         slotted_upgrades = (upgrade for upgrade in @upgrades when upgrade.data?)
         if slotted_upgrades.length > 0
@@ -3229,7 +3227,7 @@ class Ship
         bbcode
 
     toSimpleHTML: ->
-        html = """<b>#{if @pilot.display_name then @pilot.display_name else @pilot.name} (#{@pilot.points})</b><br />"""
+        html = """<b>#{if @pilot.display_name then @pilot.display_name else @pilot.name} (#{if @builder.isQuickbuild then exportObj.quickbuildsById[@quickbuildId].threat else @pilot.points})</b><br />"""
 
         slotted_upgrades = (upgrade for upgrade in @upgrades when upgrade.data?)
         if slotted_upgrades.length > 0

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -2455,9 +2455,11 @@ class Ship
         @pilot_selector.data('select2').container.show()
         if ship_type != @pilot?.ship
             # Ship changed; select first non-unique
-            @setPilot (exportObj.pilotsById[result.id] for result in @builder.getAvailablePilotsForShipIncluding(ship_type) when not exportObj.pilotsById[result.id].unique)[0]
-
-            # TODO: When no non-unique pilot is available, we should maybe select the first one not already beeing in the squad?
+            pilot = (exportObj.pilotsById[result.id] for result in @builder.getAvailablePilotsForShipIncluding(ship_type) when not exportObj.pilotsById[result.id].unique)[0]
+            if pilot # if there is a non-unique, use this one
+                @setPilot pilot
+            else # otherwise just set it to the first available pilot
+                @setPilot (exportObj.pilotsById[result.id] for result in @builder.getAvailablePilotsForShipIncluding(ship_type) when (not exportObj.pilotsById[result.id].restriction_func? or exportObj.pilotsById[result.id].restriction_func({builder: @})))[0]
 
         # Clear ship background class
         for cls in @row.attr('class').split(/\s+/)

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -3409,7 +3409,7 @@ class Ship
             equipped_upgrades = []
             for upgrade in @upgrades
                 func = upgrade?.data?.validation_func ? upgrade?.data?.restriction_func ? undefined
-                if (func? and not func(this, upgrade)) or (upgrade?.data? and upgrade.data in equipped_upgrades)
+                if ((func? and not func(this, upgrade)) or (upgrade?.data? and upgrade.data in equipped_upgrades)) and not @builder.isQuickbuild # check restriction func, check limited (is upgrade already in equipped_upgrades?), ignore building rules for Quickbuild
                     #console.log "Invalid upgrade: #{upgrade?.data?.name}"
                     upgrade.setById null
                     valid = false

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -2459,7 +2459,7 @@ class Ship
             if pilot # if there is a non-unique, use this one
                 @setPilot pilot
             else # otherwise just set it to the first available pilot
-                @setPilot (exportObj.pilotsById[result.id] for result in @builder.getAvailablePilotsForShipIncluding(ship_type) when (not exportObj.pilotsById[result.id].restriction_func? or exportObj.pilotsById[result.id].restriction_func({builder: @})))[0]
+                @setPilot (exportObj.pilotsById[result.id] for result in @builder.getAvailablePilotsForShipIncluding(ship_type) when ((not exportObj.pilotsById[result.id].restriction_func? or exportObj.pilotsById[result.id].restriction_func(@)) and not (exportObj.pilotsById[result.id] in @builder.uniques_in_use.Pilot)))[0]
 
         # Clear ship background class
         for cls in @row.attr('class').split(/\s+/)


### PR DESCRIPTION
Known Issues: 
- The pilot dropdown is only checking the collection for the actual pilot card, not for the upgrade cards. Thus, a pilot may not be colored red, if he belongs to upgrades that are not available. The "you cannot field that squad" note is working as it should. 
- ~~The mouse over does not work for selecting pilots (I am going to fix that)~~ fixed
- so far only TIE fighter data added 

This PR is already here to show how to contribute by adding data for the other quickbuilds. 