### PR TITLE
add help text for reddit formatting

### DIFF
--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -292,6 +292,7 @@ class exportObj.SquadBuilder
                 </div>
                 <div class="reddit-list">
                     <p>Copy the below and paste it into your reddit post.</p>
+                    <p>Make sure that the post editor is set to markdown mode.</p>
                     <textarea></textarea><button class="btn btn-copy">Copy</button>
                 </div>
                 <div class="tts-list">


### PR DESCRIPTION
There's a fair bit of confusion on how to paste the output from the reddit formatter into Reddit, So I added a sentence to let users know that they need to use markdown mode in the reddit post editor.
![Screen Shot 2019-04-05 at 10 08 17 AM](https://user-images.githubusercontent.com/7219131/55633613-c395f980-578a-11e9-9d53-a73fcefb02f6.png)

