### PR TITLE
Change Nashtah Pup to initiative 0

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -4216,7 +4216,7 @@ exportObj.basicCardData = ->
             unique: true
             faction: "Scum and Villainy"
             ship: "Z-95 Headhunter"
-            skill: 1
+            skill: 0
             points: 6
             slots: [
                 "Missile"


### PR DESCRIPTION
The NP does not have an initiative - it inherits the initiative of the Hounds Tooth that it escapes from.  For this reason, setting the initiative to an non-standard value (like zero) would set it apart more than it having an initiative of 1.  Also, this would make less noise in my data validator! :)