### PR TITLE
Fixes Issue with squads containing dependencies on special cases

### DIFF
--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -3583,6 +3583,7 @@ class Ship
                                 upgrade_selection.setById upgrade_id
                                 if upgrade_selection.lastSetValid
                                     upgrade_ids.splice(i,1) # added successfully, remove from list
+                                    console.log(upgrade_ids)
                                 break
                 everythingadded &= upgrade_ids.length == 0
 
@@ -3829,7 +3830,12 @@ class GenericAddon
             @rescindAddons()
             @deoccupyOtherUpgrades()
             if new_data?.unique? or new_data?.solitary?
-                await @ship.builder.container.trigger 'xwing:claimUnique', [ new_data, @type, defer() ]
+                try
+                    await @ship.builder.container.trigger 'xwing:claimUnique', [ new_data, @type, defer() ]
+                catch alreadyClaimed
+                    @ship.builder.container.trigger 'xwing:pointsUpdated'
+                    @lastSetValid = false
+                    return
             # Need to make a copy of the data, but that means I can't just check equality
             @data = @unadjusted_data = new_data
 

--- a/coffeescripts/xwing.coffee
+++ b/coffeescripts/xwing.coffee
@@ -3583,7 +3583,6 @@ class Ship
                                 upgrade_selection.setById upgrade_id
                                 if upgrade_selection.lastSetValid
                                     upgrade_ids.splice(i,1) # added successfully, remove from list
-                                    console.log(upgrade_ids)
                                 break
                 everythingadded &= upgrade_ids.length == 0
 


### PR DESCRIPTION
There is an issue loading squads like this:

https://raithos.github.io/?f=Galactic%20Empire&d=v8ZsZ200Z215X122WW63W60WW82W69W164W147Y173X204W113W102W105&sn=New%20Squadron&obs=

"Squads like this" is in detail: A ship has a card with requirement, that is met on a later ship (e.g. 0-0-0 and Vader is on a following ship, or Nashta Pup, or...). The same ship has a unique card in a slot, that exists multiple times on that ship. 

This PR fixes that by catching errors on claiming uniques (simply not equipping the corresponding upgrade)