### PR TITLE
Remove '12' from Snap Shot's points array

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -10245,7 +10245,7 @@ exportObj.basicCardData = ->
             name: "Snap Shot"
             id: 256
             slot: "Talent"
-            pointsarray: [7,8,9,12]
+            pointsarray: [7,8,9]
             variablebase: true
             attack: 2
             range: """2"""


### PR DESCRIPTION
Not sure why this was there