### PR TITLE
Fix Kylo Ren wing leader quick build

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -16561,7 +16561,7 @@ exportObj.basicCardData = ->
             id: 410
             faction: "First Order"
             pilot: "Kylo Ren"
-            ship: "TIE Silencer"
+            ship: "TIE/VN Silencer"
             threat: [6,8]
             wingmates: [2,3]
             suffix: " and his wing"


### PR DESCRIPTION
I think this is the reason that the quick build doesn't show up in the drop down.

See #464