### PR TITLE
Fix spelling error in quickbuilds

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -12312,7 +12312,7 @@ exportObj.basicCardData = ->
             threat: 2
             upgrades: [
                 "Fire-Control System"
-                "Proton Torpedos"
+                "Proton Torpedoes"
                 "Advanced SLAM"
                 "Os-1 Arsenal Loadout"
             ]


### PR DESCRIPTION
Nu Squadron Pilot has 'Torpedos' instead of 'Torpedoes'