### PR TITLE
Quickbuild Typo

### DIFF
--- a/coffeescripts/cards-common.coffee
+++ b/coffeescripts/cards-common.coffee
@@ -12692,7 +12692,7 @@ exportObj.basicCardData = ->
             ship: "K-Wing"
             threat: 2
             upgrades: [
-                "Barrage Rocktes"
+                "Barrage Rockets"
                 "Bomblet Generator"
             ]
         }


### PR DESCRIPTION
Warden Sq Pilot has 'Rocktes' instead of 'Rockets'