### PR TITLE
Fix grey background printing issue

### DIFF
--- a/stylesheets/xwing-print.sass
+++ b/stylesheets/xwing-print.sass
@@ -12,6 +12,7 @@ $upgrade-circle-border-width: 0.0625in
 body
   -webkit-print-color-adjust: exact
   color-adjust: exact !important
+  background-color: white
   zoom: 75%
 
 .modal-backdrop


### PR DESCRIPTION
Closes #588 

There are still some issues with the range indicators beeing just black boxes, but I did not find the cause for that in a reasonable amount of time. 