### PR TITLE
Fixed Moff Jerjerrod not being valid on red coordinate

### DIFF
--- a/coffeescripts/content/cards-common.coffee
+++ b/coffeescripts/content/cards-common.coffee
@@ -9529,7 +9529,7 @@ exportObj.basicCardData = ->
            charge: 2
            recurring: true
            restriction_func: (ship) ->
-                ("Coordinate" or "R-Coordinate") in ship.effectiveStats().actions
+                ship.effectiveStats().actions.some( (action) -> action in ["Coordinate", "R-Coordinate"] )
        }
        {
            name: "Magva Yarro"


### PR DESCRIPTION
Never done CoffeeScript before, but it seems like the existing logic did
a boolean short-circuit, causing Moff Jerjerrod to ONLY work for a white
coordinate, and not a red one. I'm not sure if the way I fixed this is
the CoffeeScript way of doing it, but it seems to work.