### PR TITLE
Quickfix: Collection failes to translate

### DIFF
--- a/coffeescripts/system/xwing.coffee
+++ b/coffeescripts/system/xwing.coffee
@@ -1221,7 +1221,7 @@ class exportObj.SquadBuilder
             # console.log "#{@faction}: collection was created"
             @collection = collection
             # console.log "#{@faction}: Collection created, checking squad"
-            @collection.onLanguageChange null, @language
+            # @collection.onLanguageChange null, @language
             @checkCollection()
             @collection_button.removeClass 'd-none'
         .on 'xwing-collection:changed', (e, collection) =>
@@ -1474,7 +1474,7 @@ class exportObj.SquadBuilder
         @unreleased_content_used_container.toggleClass 'd-none', not unreleased_content_used
 
         @fancy_total_points_container.text @total_points
-
+        
         # update text list
         @fancy_container.text ''
         @simple_container.html '<table class="simple-table"></table>'

--- a/coffeescripts/system/xwing.coffee
+++ b/coffeescripts/system/xwing.coffee
@@ -2630,7 +2630,7 @@ class exportObj.SquadBuilder
                     
                     if @collection?.counts?
                         addon_count = @collection.counts?['upgrade']?[data.name] ? 0
-                        container.find('.info-collection').text @uitranslation(collectionContentUpgrades, addon_count)
+                        container.find('.info-collection').text @uitranslation("collectionContentUpgrades", addon_count)
                         container.find('.info-collection').show()
                     else
                         container.find('.info-collection').hide()


### PR DESCRIPTION
This fix allows to run the UI translation rework. The collection will not be translated. 

I basically missed, that `manifest.coffee` does contain a bunch of system code, even though it should just be content. Actually there is even html inside it, that needs to receive the new translation tags. 

I'm not sure, if the system like code should be moved from the manifest to e.g. the backend? Would maybe feel a bit cleaner. 