### PR TITLE
Show point cost range in ship select

### DIFF
--- a/coffeescripts/system/browser.coffee
+++ b/coffeescripts/system/browser.coffee
@@ -306,10 +306,10 @@ class exportObj.CardBrowser
 
         @card_selector_container = $ @container.find('.xwing-card-browser .card-selector-container')
         @card_viewer_container = $ @container.find('.xwing-card-browser .card-viewer-container')
-        @card_viewer_container.append $.trim exportObj.builders[0].createInfoContainerUI()
+        @card_viewer_container.append $.trim exportObj.builders[7].createInfoContainerUI()
         @card_viewer_container.hide()
         @card_viewer_conditions_container = $ @container.find('.xwing-card-browser .card-viewer-conditions-container')
-        @card_viewer_container.hide()
+        @card_viewer_conditions_container.hide()
         @card_viewer_placeholder = $ @container.find('.xwing-card-browser .card-viewer-placeholder')
         @advanced_search_container = $ @container.find('.xwing-card-browser .advanced-search-container')
 
@@ -595,7 +595,7 @@ class exportObj.CardBrowser
             add_opts = {addon_type: orig_type}
             orig_type = 'Addon'
 
-        exportObj.builders[0].showTooltip(orig_type, data, add_opts ? {}, @card_viewer_container) # we use the render method from the squad builder, cause it works.
+        exportObj.builders[7].showTooltip(orig_type, data, add_opts ? {}, @card_viewer_container) # we use the render method from the squad builder, cause it works.
 
         @card_viewer_container.show()
 
@@ -633,16 +633,16 @@ class exportObj.CardBrowser
 
     getCollectionNumber: (card) ->
         # returns number of copies of the given card in the collection, or -1 if no collection loaded
-        if not (exportObj.builders[0].collection? and exportObj.builders[0].collection.counts?)
+        if not (exportObj.builders[7].collection? and exportObj.builders[7].collection.counts?)
             return -1
         owned_copies = 0
         switch card.orig_type
             when 'Pilot'
-                owned_copies = exportObj.builders[0].collection.counts.pilot?[card.name] ? 0
+                owned_copies = exportObj.builders[7].collection.counts.pilot?[card.name] ? 0
             when 'Ship'
-                owned_copies = exportObj.builders[0].collection.counts.ship?[card.name] ? 0
+                owned_copies = exportObj.builders[7].collection.counts.ship?[card.name] ? 0
             else # type is e.g. astromech
-                owned_copies = exportObj.builders[0].collection.counts.upgrade?[card.name] ? 0
+                owned_copies = exportObj.builders[7].collection.counts.upgrade?[card.name] ? 0
         owned_copies
 
 
@@ -797,7 +797,7 @@ class exportObj.CardBrowser
         return false if card.data.charge and not card.data.recurring and not @not_recurring_charge.checked
 
         # check collection status
-        if exportObj.builders[0].collection?.counts? # ignore collection stuff, if no collection available
+        if exportObj.builders[7].collection?.counts? # ignore collection stuff, if no collection available
             owned_copies = @getCollectionNumber(card)
             return false unless owned_copies >= @minimum_owned_copies.value and owned_copies <= @maximum_owned_copies.value
 
@@ -865,3 +865,5 @@ class exportObj.CardBrowser
         #TODO: Add logic of addiditional search criteria here. Have a look at card.data, to see what data is available. Add search inputs at the todo marks above. 
 
         return true
+
+

--- a/coffeescripts/system/xwing.coffee
+++ b/coffeescripts/system/xwing.coffee
@@ -1095,6 +1095,10 @@ class exportObj.SquadBuilder
                             <td class="info-header translated" defaultText="Initiative"></td>
                             <td class="info-data info-skill"></td>
                         </tr>
+                        <tr class="info-points">
+                            <td class="info-header translated" defaultText="Points"></td>
+                            <td class="info-data info-points"></td>
+                        </tr>
                         <tr class="info-engagement">
                             <td class="info-header translated" defaultText="Engagement"></td>
                             <td class="info-data info-engagement"></td>
@@ -2245,14 +2249,17 @@ class exportObj.SquadBuilder
                 when 'Ship'
             # we get all pilots for the ship, to display stuff like available slots which are treated as pilot properties, not ship properties (which makes sense, as they depend on the pilot, e.g. talent or force slots)
                     possible_inis = []
+                    possible_costs = []
                     slot_types = {} # one number per slot: 0: not available for that ship. 1: always available for that ship. 2: available for some pilots on that ship. 3: slot two times availabel for that ship 4: slot one or two times available (depending on pilot) 5: slot zero to two times available 6: slot three times available (no mixed-case implemented) -1: undefined
                     for slot of exportObj.upgradesBySlotCanonicalName
                         slot_types[slot] = -1
                     for name, pilot of exportObj.pilots
-                        if pilot.ship != data.name 
+                        # skip all pilots with wrong ship or faction
+                        if pilot.ship != data.name or not @isOurFaction(pilot.faction) 
                             continue
                         if not (pilot.skill in possible_inis)
                             possible_inis.push(pilot.skill)
+                        possible_costs.push(pilot.points)
                         for slot, state of slot_types
                             switch pilot.slots.filter((item) => item == slot).length
                                 when 1
@@ -2300,6 +2307,15 @@ class exportObj.SquadBuilder
                         first = false
                     container.find('tr.info-skill td.info-data').text inis
                     container.find('tr.info-skill').show()
+
+                    # display point range for that ship (and faction) 
+                    point_range_text = "#{Math.min possible_costs...} - #{Math.max possible_costs...}"
+                    container.find('tr.info-points td.info-data').text point_range_text
+                    # don't display point range in Quickbuild (or ToDo: Display Threat range instead)
+                    if @isQuickbuild
+                        container.find('tr.info-points').hide()
+                    else
+                        container.find('tr.info-points').show()
                     
                     container.find('tr.info-engagement').hide()
                 
@@ -2443,6 +2459,7 @@ class exportObj.SquadBuilder
                         container.find('tr.info-engagement').show()
                     else
                         container.find('tr.info-engagement').hide()
+                    container.find('tr.info-points').hide()
                     
                     
 #                    for cls in container.find('tr.info-attack td.info-header i.xwing-miniatures-font')[0].classList
@@ -2583,6 +2600,7 @@ class exportObj.SquadBuilder
 
                     container.find('tr.info-skill td.info-data').text pilot.skill
                     container.find('tr.info-skill').show()
+                    container.find('tr.info-points').hide()
                     container.find('tr.info-engagement td.info-data').text pilot.skill
                     container.find('tr.info-engagement').show()
 
@@ -2702,6 +2720,7 @@ class exportObj.SquadBuilder
                     container.find('tr.info-ship').hide()
                     container.find('tr.info-base').hide()
                     container.find('tr.info-skill').hide()
+                    container.find('tr.info-points').hide()
                     container.find('tr.info-engagement').hide()
                     if data.energy?
                         container.find('tr.info-energy td.info-data').text data.energy
@@ -2807,6 +2826,7 @@ class exportObj.SquadBuilder
                     container.find('tr.info-ship').hide()
                     container.find('tr.info-base').hide()
                     container.find('tr.info-skill').hide()
+                    container.find('tr.info-points').hide()
                     container.find('tr.info-agility').hide()
                     container.find('tr.info-hull').hide()
                     container.find('tr.info-shields').hide()
@@ -2847,6 +2867,7 @@ class exportObj.SquadBuilder
                     container.find('tr.info-ship').hide()
                     container.find('tr.info-base').hide()
                     container.find('tr.info-skill').hide()
+                    container.find('tr.info-points').hide()
                     container.find('tr.info-agility').hide()
                     container.find('tr.info-hull').hide()
                     container.find('tr.info-shields').hide()

--- a/coffeescripts/translations/cards-de.coffee
+++ b/coffeescripts/translations/cards-de.coffee
@@ -251,6 +251,7 @@ is an authorization system which lets you prove your identity at a web site with
         "Rules Search": "Regelsuche"
         "Base": "Schiffsgröße"
         "Ship": "Schiff"
+        "Points": "Punkte"
         "Initiative": "Initiativewert"
         "Force:": "Machtwert:"
         "Name": "Name"


### PR DESCRIPTION
This PR also fixes a bug, causing wrong inis to show up in multi-faction ships (e.g. a TIE/ln showing ini 1-5 for rebels).

Possible further enhancements that could be done:
  * show thread range in quick build mode
  * make sure to only show hyperspace points/inis in hyperspace mode
  * Format numbers nicer (e.g. "Ini: 1-5" instead of "Ini: 1,2,3,4,5". For points: epic ships with just one pilot points: 130 instead of points: 130-130)

Closes #896 
