### PR TITLE
Fix ship name

### DIFF
--- a/coffeescripts/content/cards-common.coffee
+++ b/coffeescripts/content/cards-common.coffee
@@ -12619,7 +12619,7 @@ exportObj.basicCardData = ->
             id: 600
             unique: true
             faction: "Galactic Empire"
-            ship: "TIE/x1 Advanced"
+            ship: "TIE Advanced x1"
             skill: 5
             points: 20
             slots: [


### PR DESCRIPTION
Having a wrong ship name caused the card browser to fail as well

closes #1176 
closes #1175 
closes #1174