### PR TITLE
Correct Delta-7 Aethersprite Expansion Upgrades

### DIFF
--- a/coffeescripts/content/manifest.coffee
+++ b/coffeescripts/content/manifest.coffee
@@ -5517,46 +5517,6 @@ exportObj.manifestByExpansion =
             type: 'upgrade'
             count: 1
         }
-        {
-            name: 'Composure'
-            type: 'upgrade'
-            count: 1
-        }
-        {
-            name: 'Dedicated'
-            type: 'upgrade'
-            count: 1
-        }
-        {
-            name: 'Expert Handling'
-            type: 'upgrade'
-            count: 1
-        }
-        {
-            name: 'Juke'
-            type: 'upgrade'
-            count: 1
-        }
-        {
-            name: 'Saturation Salvo'
-            type: 'upgrade'
-            count: 1
-        }
-        {
-            name: 'Swarm Tactics'
-            type: 'upgrade'
-            count: 1
-        }
-        {
-            name: 'Cluster Missiles'
-            type: 'upgrade'
-            count: 1
-        }
-        {
-            name: 'Concussion Missiles'
-            type: 'upgrade'
-            count: 1
-        }
     ]
 
     'Z-95-AF4 Headhunter Expansion Pack': [


### PR DESCRIPTION
The Delta-7 Aethersprite Expansion has too many upgrade cards listed in the manifest, resulting in incorrect collection counts. Should be only:

1 Battle Meditation
1 Briliant Evasion
1 Calibrated Laser Targeting
1 Delta-7B
1 R3 Astromech
1 R4-P Astromech

https://www.fantasyflightgames.com/en/products/x-wing-second-edition/products/delta-7-aethersprite-expansion/ https://xwing-miniatures-second-edition.fandom.com/wiki/Delta-7_Aethersprite_Expansion_Pack