### PR TITLE
TIE/in Expansion missing Shield Upgrade

### DIFF
--- a/coffeescripts/content/manifest.coffee
+++ b/coffeescripts/content/manifest.coffee
@@ -7785,6 +7785,11 @@ exportObj.manifestByExpansion =
             count: 1
         }
         {
+            name: 'Shield Upgrade'
+            type: 'upgrade'
+            count: 1
+        }
+        {
             name: 'Daredevil'
             type: 'upgrade'
             count: 1


### PR DESCRIPTION
The TIE/in Interceptor Expansion Pack also has a copy of 'Shield Upgrade', which is missing from the manifest

https://www.fantasyflightgames.com/en/products/x-wing-second-edition/products/x-wing-second-edition-tie-interceptor-expansion-pack/ https://xwing-miniatures-second-edition.fandom.com/wiki/TIE/in_Interceptor_Expansion_Pack