### PR TITLE
Correction to Manifest for Servants of Strife and Jango Fetts Slave I

### DIFF
--- a/coffeescripts/content/manifest.coffee
+++ b/coffeescripts/content/manifest.coffee
@@ -4842,11 +4842,6 @@ exportObj.manifestByExpansion =
             count: 2
         }
         {
-            name: 'Cluster Missiles'
-            type: 'upgrade'
-            count: 1
-        }
-        {
             name: 'Afterburners'
             type: 'upgrade'
             count: 3

--- a/coffeescripts/content/manifest.coffee
+++ b/coffeescripts/content/manifest.coffee
@@ -8484,6 +8484,11 @@ exportObj.manifestByExpansion =
             count: 1
         }
         {
+            name: 'Jamming Beam'
+            type: 'upgrade'
+            count: 1
+        }
+        {
             name: 'Slave I (Separatist)'
             type: 'upgrade'
             count: 1


### PR DESCRIPTION
Servants of Strife Squadron Pack
 - Cluster Missiles upgrade included twice in manifest (2 count + 1 count), removed the 1 count copy
Jango Fett's Slave I Expansion Pack
 - Missing 1 x Jamming Beam