### PR TITLE
Correct manifest for TIE/rb Heavy Expansion

### DIFF
--- a/coffeescripts/content/manifest.coffee
+++ b/coffeescripts/content/manifest.coffee
@@ -8379,7 +8379,7 @@ exportObj.manifestByExpansion =
         {
             name: 'Snap Shot'
             type: 'upgrade'
-            count: 1
+            count: 2
         }
         {
             name: 'Ablative Plating'


### PR DESCRIPTION
TIE/rb Heavy Expansion includes 2 x Snap Shot (as per the other two Talent upgrades included in the expansion). Updated manifest.coffee from 1 count to 2 count.