### PR TITLE
Margins and paddings adjustments

### DIFF
--- a/stylesheets/xwing.sass
+++ b/stylesheets/xwing.sass
@@ -89,8 +89,9 @@ strong em, em strong
   font-style: normal
   font-weight: normal
 
-.side-button
-  margin-top: 5px
+@media (max-width: 768px)
+  .side-button
+    margin-top: 5px
 
 .flavor_text 
   display: none
@@ -152,11 +153,13 @@ i.xwing-miniatures-font-frontarc, i.xwing-miniatures-font-reararc, i.xwing-minia
   padding-left: 9px
   padding-right: 9px
   padding-bottom: 7px
+  padding-top: 7px
 
 i.xwing-miniatures-font-singleturretarc, i.xwing-miniatures-font-doubleturretarc
   padding-left: 11px
   padding-right: 11px
   padding-bottom: 7px
+  padding-top: 7px
 
 i.xwing-miniatures-font-rangebonusindicator
   font-size: 1.1em
@@ -174,6 +177,7 @@ i.header-agility
   padding-left: 7px
   padding-right: 7px
   padding-bottom: 6px
+  padding-top: 7px
 
 i.header-hull
   @extend .card-icon
@@ -181,6 +185,7 @@ i.header-hull
   padding-left: 10px
   padding-right: 10px
   padding-bottom: 7px
+  padding-top: 7px
 
 i.header-shield
   @extend .card-icon
@@ -188,6 +193,7 @@ i.header-shield
   padding-left: 8px
   padding-right: 8px
   padding-bottom: 8px
+  padding-top: 8px
 
 i.header-force
   @extend .card-icon
@@ -195,6 +201,7 @@ i.header-force
   padding-left: 7px
   padding-right: 7px
   padding-bottom: 7px
+  padding-top: 7px
 
 i.header-charge
   @extend .card-icon
@@ -202,6 +209,7 @@ i.header-charge
   padding-left: 9px
   padding-right: 9px
   padding-bottom: 7px
+  padding-top: 7px
 
 i.header-range
   vertical-align: middle


### PR DESCRIPTION
Removed a margin top in side buttons in order to align then with the rest of the components in the row. Only in desktop view since this buttons are presented in the botton in mobile and the margin is required.
![Buttons aligment](https://github.com/user-attachments/assets/11338ba8-0b6e-4f87-bbef-ec5bfcbb45b4)

Mobile view unchanged:
<img width="573" alt="Mobile margin unchanged" src="https://github.com/user-attachments/assets/e56dfad6-6313-4dc6-adec-24580c3b638a">

Added some padding in the ship stats indicators to make them round:
![Ship stats indicators](https://github.com/user-attachments/assets/90c72a22-f25a-4084-a7ad-88d37ef3c6cf)
