### PR TITLE
Mobile header changes and svg cancel icon

### DIFF
--- a/coffeescripts/system/xwing.coffee
+++ b/coffeescripts/system/xwing.coffee
@@ -250,7 +250,7 @@ class exportObj.SquadBuilder
                         <input type="text" maxlength="64" placeholder="#{@uitranslation("Name your squad...")}" />
                         <button class="btn save"><i class="fa fa-pen-square"></i></button>
                     </div>
-                    <br />
+                    <br class="hide-on-mobile" />
                     <select class="game-type-selector">
                         <option value="xwabeta" class="translated" defaultText="XWA Beta">#{@uitranslation("XWA Beta")}</option>
                         <option value="standard" class="translated" defaultText="Standard" selected="selected">#{@uitranslation("Standard")}</option>

--- a/stylesheets/xwing-screen.sass
+++ b/stylesheets/xwing-screen.sass
@@ -321,8 +321,8 @@ $upgrade-circle-border-width: 5px
         width: 20px
         height: 20px
         right: 20px
-        top: 3px
-        background-image: url(../images/cancel.png) !important
+        top: 2px
+        background-image: url('data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjIuODggMTIyLjg4Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2Y0NDMzNjtmaWxsLXJ1bGU6ZXZlbm9kZDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmNsb3NlLXJlZDwvdGl0bGU+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNjEuNDQsMEE2MS40NCw2MS40NCwwLDEsMSwwLDYxLjQ0LDYxLjQ0LDYxLjQ0LDAsMCwxLDYxLjQ0LDBaTTc0LjU4LDM2LjhjMS43NC0xLjc3LDIuODMtMy4xOCw1LTFsNyw3LjEzYzIuMjksMi4yNiwyLjE3LDMuNTgsMCw1LjY5TDczLjMzLDYxLjgzLDg2LjA4LDc0LjU4YzEuNzcsMS43NCwzLjE4LDIuODMsMSw1bC03LjEzLDdjLTIuMjYsMi4yOS0zLjU4LDIuMTctNS42OCwwTDYxLjQ0LDczLjcyLDQ4LjYzLDg2LjUzYy0yLjEsMi4xNS0zLjQyLDIuMjctNS42OCwwbC03LjEzLTdjLTIuMi0yLjE1LS43OS0zLjI0LDEtNWwxMi43My0xMi43TDM2LjM1LDQ4LjY0Yy0yLjE1LTIuMTEtMi4yNy0zLjQzLDAtNS42OWw3LTcuMTNjMi4xNS0yLjIsMy4yNC0uNzksNSwxTDYxLjQ0LDQ5Ljk0LDc0LjU4LDM2LjhaIi8+PC9zdmc+')!important
         background-size: 20px 20px !important
     .select2-container .select2-choice abbr:hover
         background-position: right 0px

--- a/stylesheets/xwing.sass
+++ b/stylesheets/xwing.sass
@@ -100,8 +100,6 @@ strong em, em strong
     gap: 4px
   .display-name
     margin: 4px
-  h2
-    font-size: 1.6rem
 
 .flavor_text 
   display: none

--- a/stylesheets/xwing.sass
+++ b/stylesheets/xwing.sass
@@ -92,6 +92,16 @@ strong em, em strong
 @media (max-width: 768px)
   .side-button
     margin-top: 5px
+  .hide-on-mobile
+    display: none
+  .squad-name-container
+   text-align: center
+  .squad-name-and-points-row
+    gap: 4px
+  .display-name
+    margin: 4px
+  h2
+    font-size: 1.6rem
 
 .flavor_text 
   display: none


### PR DESCRIPTION
1- Changed the alignment and spacing for the components in the header, only for mobile view.
![Mobile header](https://github.com/user-attachments/assets/79a459fb-669d-424a-b0f2-595c64bd4aa7)

2- Changed the remove upgrade icon from png to svg (png icon is not under source control).
![SVG image](https://github.com/user-attachments/assets/3c4a9ced-706f-41ab-adce-662a3ae5b57d)

~~3- Reduced a bit the size of the title in the card intro.~~
