### PR TITLE
Fix randomizer

### DIFF
--- a/coffeescripts/system/xwing.coffee
+++ b/coffeescripts/system/xwing.coffee
@@ -3248,7 +3248,7 @@ class exportObj.SquadBuilder
                             available_upgrades = (upgrade for upgrade in @getAvailableUpgradesIncluding(addon.slot, null, ship, addon,'', @dfl_filter_func, sorted = false) when (exportObj.upgradesById[upgrade.id].sources.intersects(data.allowed_sources) and ((not data.collection_only) or @collection.checkShelf('upgrade', upgrade.name))) and not upgrade.disabled)
                             if available_upgrades.length > 0
                                 upgrade =  available_upgrades[$.randomInt available_upgrades.length] 
-                                addon.setById upgrade.id
+                                await addon.setById upgrade.id
                             else
                                 # that slot has only expensive stuff. ignore it in the future!
                                 expensive_slots.push addon


### PR DESCRIPTION
The randomizer was able to remove ships while upgrades were currently in the process of adding themself. This resulted in an error message in the logs (though I did not observe any impact on the UI/behaviour). Nevertheless, his should fix this. 