### PR TITLE
Fix issues - hopefully

### DIFF
--- a/coffeescripts/content/cards-common.coffee
+++ b/coffeescripts/content/cards-common.coffee
@@ -5820,6 +5820,7 @@ exportObj.basicCardData = ->
             ]
             slotsbeta: [
                 "Talent"
+                "Modification"
                 "Configuration"
             ]
         }

--- a/coffeescripts/system/xwing.coffee
+++ b/coffeescripts/system/xwing.coffee
@@ -1709,7 +1709,7 @@ class exportObj.SquadBuilder
             @container.trigger 'xwing-backend:squadNameChanged'
             @container.trigger 'xwing-backend:squadDirtinessChanged'
             cb()
-        if squad.serialized.length?
+        if squad.serialized?.length?
             @loadFromSerialized squad.serialized, afterLoading
         else:
             afterLoading()


### PR DESCRIPTION
So, this PR tries to pass on the callback required to save a squad after it's loaded (and possibly updated to new points). It's somewhat untested, so not sure it works. Before you hit the recalculate button to test it, make sure you're fine with loosing all squads ;-) It may or may not be able to fix 1455 (deliberately not # it, so it doesn't get closed on merge...)

This PR also adds the missing mod slot to saber squadron ACE, so it closes #1459 #1458 

Lastly, it makes YASB switch to XWA/AMG points on loading XWS, if specified in the XWS (loading XWS was the closest I'd get to loading lists via backend, so that's where I noticed this might be a nice thing to do). 