### PR TITLE
Remove Tractor Tentacles from autoequip

### DIFF
--- a/coffeescripts/content/cards-common.coffee
+++ b/coffeescripts/content/cards-common.coffee
@@ -2028,9 +2028,6 @@ exportObj.basicCardData = ->
                 [ 0, 0, 1, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0 ]
                 [ 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
             ]
-            autoequip: [
-                'Tractor Tentacles'
-            ]
 
     # name field is for convenience only
     pilotsById: [


### PR DESCRIPTION
Pre build Asaji Ventress would somehow receive two copies otherwise

The cleaner solution would probably be preventing autoequip to occur for pilots that have an `upgrades` array defined (I'm surprised that isn't the case right now)? However, I'm too lazy to do so right now. 

closes #1465 