### PR TITLE
Fix async issues

### DIFF
--- a/coffeescripts/system/xwing.coffee
+++ b/coffeescripts/system/xwing.coffee
@@ -650,7 +650,7 @@ class exportObj.SquadBuilder
             @onGameTypeChanged @game_type_selector.val()
         @desired_points_input = $ @points_container.find('.desired-points')
         @desired_points_input.change (e) =>
-            @onPointsUpdated $.noop
+            @container.trigger 'xwing:pointsUpdated'
         @points_remaining_span = $ @points_container.find('.points-remaining')
         @points_destroyed_span = $ @points_container.find('.points-destroyed')
         @points_remaining_container = $ @points_container.find('.points-remaining-container')
@@ -4483,7 +4483,7 @@ class Ship
                     @points_destroyed_button_span.html '<i class="fas fa-circle"></i>'
 
 
-            @builder.onPointsUpdated()
+            @builder.container.trigger 'xwing:pointsUpdated'
         @points_destroyed_button.hide()
     
     teardownUI: ->
@@ -4954,7 +4954,7 @@ class Ship
                 # ignore those checks if this is a pilot with upgrades or quickbuild
                 if (not meets_restrictions or (upgrade?.data? and (upgrade.data in equipped_upgrades or (upgrade.data.faction? and not @builder.isOurFaction(upgrade.data.faction,@pilot.faction)) or not @builder.isItemAvailable(upgrade.data)))) and not pilot_upgrades_check and not @builder.isQuickbuild
                     console.log "Invalid upgrade: #{upgrade?.data?.name} on pilot #{@pilot?.name}"
-                    upgrade.setById null
+                    await upgrade.setById null
                     valid = false
                     unchanged = false
                     break
@@ -5327,7 +5327,7 @@ class GenericAddon
                 @deoccupyOtherUpgrades()
 
             # this will remove not allowed upgrades (is also done on pointsUpdated). We do it explicitly so we can tell if the setData was successfull
-            @lastSetValid = @ship.validate()
+            await @lastSetValid = @ship.validate()
             @ship.builder.container.trigger 'xwing:pointsUpdated'
 
     conferAddons: ->

--- a/coffeescripts/system/xwing.coffee
+++ b/coffeescripts/system/xwing.coffee
@@ -4947,13 +4947,13 @@ class Ship
                             for upgradeslot in upgrade.data.also_occupies_upgrades
                                 meets_restrictions = meets_restrictions and upgrade.occupiesAnUpgradeSlot(upgradeslot)
 
-                    restrictions = upgrade?.data?.restrictions ? undefined
+                    restrictions = if upgrade?.data?.restrictionsxwa? and @builder.isXwa then upgrade?.data?.restrictionsxwa else upgrade?.data?.restrictions ? undefined
                     # always perform this check, even if no special restrictions for this upgrade exists, to check for allowed points
                     meets_restrictions = meets_restrictions and @restriction_check(restrictions, upgrade, upgrade.getPoints(), @upgrade_points_total)
 
                 # ignore those checks if this is a pilot with upgrades or quickbuild
                 if (not meets_restrictions or (upgrade?.data? and (upgrade.data in equipped_upgrades or (upgrade.data.faction? and not @builder.isOurFaction(upgrade.data.faction,@pilot.faction)) or not @builder.isItemAvailable(upgrade.data)))) and not pilot_upgrades_check and not @builder.isQuickbuild
-                    console.log "Invalid upgrade: #{upgrade?.data?.name}, check #{@pilot?.upgrades} on pilot #{@pilot?.name}"
+                    console.log "Invalid upgrade: #{upgrade?.data?.name} on pilot #{@pilot?.name}"
                     upgrade.setById null
                     valid = false
                     unchanged = false


### PR DESCRIPTION
I'd bet there are more occassions where we did not add the differentiation between xwa and amg restrictions.

I've found one bug related to restrictions: If you Equip a Lambda-Shuttle with a targeting computer and Grand Moff Tarkin and then remove the targeting computer, an error is thrown. Validation was called twice in parallel (l. 5329ff), resulting in this dublicated removal. We now validate the current ship first and only after that's done we validate all the other ships. 

closes #1468 