### PR TITLE
More fixes to standardized + Rogue-Class

### DIFF
--- a/coffeescripts/content/cards-common.coffee
+++ b/coffeescripts/content/cards-common.coffee
@@ -21027,6 +21027,7 @@ exportObj.basicCardData = ->
         {
             name: "C-3PO (Epic)"
             id: 536
+            xwsaddon: "epicsl"
             standard: true
             unique: true
             slot: "Crew"

--- a/coffeescripts/content/cards-common.coffee
+++ b/coffeescripts/content/cards-common.coffee
@@ -6795,6 +6795,7 @@ exportObj.basicCardData = ->
                 "Force"
                 "Force"
                 "Sensor"
+                "Tech"
                 "Torpedo"
                 "Crew"
                 "Crew"

--- a/coffeescripts/content/cards-common.coffee
+++ b/coffeescripts/content/cards-common.coffee
@@ -21028,7 +21028,6 @@ exportObj.basicCardData = ->
         {
             name: "C-3PO (Epic)"
             id: 536
-            xwsaddon: "epicsl"
             standard: true
             unique: true
             slot: "Crew"

--- a/coffeescripts/system/xwing.coffee
+++ b/coffeescripts/system/xwing.coffee
@@ -5135,6 +5135,7 @@ class Ship
 
         if checkstandard
             for ship in @builder.ships
+                if ship == this then continue
                 if ship?.data? and ship.data.name == @data.name
                     if restrictions? and ship.restriction_check(restrictions, upgrade_data) and not (ship.pilot?.upgrades?)
                         if ship.pilot.loadout? and (upgrade_data.points + ship.upgrade_points_total > ship.pilot.loadout)

--- a/coffeescripts/system/xwing.coffee
+++ b/coffeescripts/system/xwing.coffee
@@ -4120,13 +4120,22 @@ class Ship
                         for upgrade in @upgrades
                             if exportObj.slotsMatching(upgrade.slot, auto_equip_upgrade.slot)
                                 upgrade.setData auto_equip_upgrade
+                # check if we need to add a standard upgrade
+                # see if ship is supposed to be standardized
+                standard_upgrade_to_check = @checkStandardizedList(@pilot.ship)
+                if standard_upgrade_to_check?
+                    old_upgrades[standard_upgrade_to_check.slot] ?= []
+                    if standard_upgrade_to_check.id not in old_upgrades[standard_upgrade_to_check.slot]
+                        # if that upgrade was not present in the old upgrades, but is required now, we add it at first position
+                        old_upgrades[standard_upgrade_to_check.slot].unshift standard_upgrade_to_check.id
+                
                 if same_ship and not @pilot.upgrades?
                     # two cycles, in case an old upgrade is adding slots that are required for other old upgrades
                     for _ in [1..2]
                         delayed_upgrades = {}
                         for upgrade in @upgrades
                             # check if there exits old upgrades for this slot - if so, try to add the first of them
-                            old_upgrade = (old_upgrades[upgrade.slot] ? []).shift()
+                            old_upgrade = (old_upgrades[upgrade.slot] ? []).pop()
                             if old_upgrade?
                                 await upgrade.setById old_upgrade
                                 if not upgrade.lastSetValid
@@ -4136,12 +4145,6 @@ class Ship
                         for id, upgrade of delayed_upgrades
                             upgrade.setById id
                         # last check for standardized
-                    # see if ship is supposed to be standardized
-                    standard_upgrade_to_check = @checkStandardizedList(@pilot.ship)
-                    standard_check = false
-                    for upgrade in @upgrades
-                        if standard_upgrade_to_check? and (upgrade?.data?.name? and (upgrade.data.name == standard_upgrade_to_check.name))
-                            standard_check = true
             else
                 @copy_button.hide()
             @row.removeClass('unsortable')


### PR DESCRIPTION
from what I can tell, lines 4139-4144 didn't do anything: They checked if the required standardized upgrade is there, but didn't act in any way if it wasn't. Now we just put it in our list of "old upgrades" that are supposed to be added. This seems to work from what I can tested...

also this PR allows to switch to a standardized upgrade from an occupied slot. 

closes #1584 (for the 3rd time :P)